### PR TITLE
feat: Add BAM alignment statistics (bam_stat) — replaces RSeQC bam_stat.py

### DIFF
--- a/src/bamstat.rs
+++ b/src/bamstat.rs
@@ -1,0 +1,336 @@
+//! BAM alignment statistics output.
+//!
+//! Produces summary statistics for BAM files, compatible with the output format
+//! of RSeQC's `bam_stat.py`. All counters are collected during the main counting
+//! pass — no additional BAM traversal is required.
+
+use crate::counting::CountResult;
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::path::Path;
+
+/// Write BAM alignment statistics in RSeQC bam_stat.py compatible format.
+///
+/// # Arguments
+///
+/// * `path` - Output file path
+/// * `result` - Counting results containing all BAM statistics
+/// * `bam_path` - Path to the source BAM file (included in header)
+pub fn write_bam_stat(path: &Path, result: &CountResult, bam_path: &str) -> Result<()> {
+    let file = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create BAM stat file: {}", path.display()))?;
+    let mut writer = std::io::BufWriter::new(file);
+
+    let non_primary = result.stat_non_primary_hits;
+    let mapped = result.stat_total_reads
+        - result.stat_unmapped
+        - result.stat_qc_failed
+        - result.stat_supplementary;
+    let unique = mapped.saturating_sub(result.stat_total_multi);
+
+    writeln!(writer, "#=== RustQC bam_stat (RSeQC-compatible) ===")?;
+    writeln!(writer, "#")?;
+    writeln!(writer, "# Input file: {}", bam_path)?;
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "Total records:                          {}",
+        result.stat_total_reads
+    )?;
+    writeln!(
+        writer,
+        "QC failed:                              {}",
+        result.stat_qc_failed
+    )?;
+    writeln!(
+        writer,
+        "Optical/PCR duplicate:                  {}",
+        result.stat_total_dup
+    )?;
+    writeln!(
+        writer,
+        "Non primary hits:                       {}",
+        non_primary
+    )?;
+    writeln!(
+        writer,
+        "  Secondary alignments:                 {}",
+        result.stat_secondary
+    )?;
+    writeln!(
+        writer,
+        "  Supplementary alignments:             {}",
+        result.stat_supplementary
+    )?;
+    writeln!(
+        writer,
+        "Unmapped reads:                         {}",
+        result.stat_unmapped
+    )?;
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "mapq < mapq_cut (non-unique):           {}",
+        result.stat_total_multi
+    )?;
+    writeln!(writer, "mapq >= mapq_cut (unique):              {}", unique)?;
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "Read-1:                                 {}",
+        result.stat_read1
+    )?;
+    writeln!(
+        writer,
+        "Read-2:                                 {}",
+        result.stat_read2
+    )?;
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "Reads map to '+':                       {}",
+        result.stat_plus_strand
+    )?;
+    writeln!(
+        writer,
+        "Reads map to '-':                       {}",
+        result.stat_minus_strand
+    )?;
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "Non-splice reads:                       {}",
+        result.stat_non_splice_reads
+    )?;
+    writeln!(
+        writer,
+        "Splice reads:                           {}",
+        result.stat_splice_reads
+    )?;
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "Reads mapped in proper pairs:           {}",
+        result.stat_proper_pairs
+    )?;
+    writeln!(
+        writer,
+        "Proper-paired reads map to different chrom: {}",
+        result.stat_mate_mapped_diff_chr
+    )?;
+    writeln!(
+        writer,
+        "Singletons:                             {}",
+        result.stat_singletons
+    )?;
+
+    writer.flush().context("Failed to flush BAM stat output")?;
+
+    Ok(())
+}
+
+/// Write BAM statistics in MultiQC general stats format.
+///
+/// Produces a TSV file with a YAML header that MultiQC recognises as a
+/// `generalstats` data source, providing key mapping metrics in the
+/// MultiQC General Statistics table.
+///
+/// # Arguments
+///
+/// * `path` - Output file path
+/// * `result` - Counting results containing all BAM statistics
+/// * `sample_name` - Sample name for the MultiQC row
+pub fn write_bam_stat_mqc(path: &Path, result: &CountResult, sample_name: &str) -> Result<()> {
+    let file = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create BAM stat MultiQC file: {}", path.display()))?;
+    let mut writer = std::io::BufWriter::new(file);
+
+    let total = result.stat_total_reads as f64;
+    let mapped = (result.stat_total_reads
+        - result.stat_unmapped
+        - result.stat_qc_failed
+        - result.stat_supplementary) as f64;
+    let mapped_pct = if total > 0.0 {
+        mapped / total * 100.0
+    } else {
+        0.0
+    };
+    let dup_pct = if mapped > 0.0 {
+        result.stat_total_dup as f64 / mapped * 100.0
+    } else {
+        0.0
+    };
+    let proper_pair_pct = if mapped > 0.0 {
+        result.stat_proper_pairs as f64 / mapped * 100.0
+    } else {
+        0.0
+    };
+
+    writeln!(writer, "# id: 'rustqc_bamstat'")?;
+    writeln!(writer, "# section_name: 'RustQC BAM Stats'")?;
+    writeln!(
+        writer,
+        "# description: 'BAM alignment statistics from RustQC (RSeQC bam_stat replacement)'"
+    )?;
+    writeln!(writer, "# plot_type: 'generalstats'")?;
+    writeln!(writer, "# pconfig:")?;
+    writeln!(writer, "#     total_reads:")?;
+    writeln!(writer, "#         title: 'Total Reads'")?;
+    writeln!(
+        writer,
+        "#         description: 'Total number of records in the BAM file'"
+    )?;
+    writeln!(writer, "#         format: '{{:,.0f}}'")?;
+    writeln!(writer, "#     mapped_pct:")?;
+    writeln!(writer, "#         title: '% Mapped'")?;
+    writeln!(
+        writer,
+        "#         description: 'Percentage of reads that are mapped'"
+    )?;
+    writeln!(writer, "#         max: 100")?;
+    writeln!(writer, "#         min: 0")?;
+    writeln!(writer, "#         suffix: '%'")?;
+    writeln!(writer, "#         format: '{{:.1f}}'")?;
+    writeln!(writer, "#     duplicate_pct:")?;
+    writeln!(writer, "#         title: '% Dups'")?;
+    writeln!(
+        writer,
+        "#         description: 'Percentage of mapped reads marked as duplicates'"
+    )?;
+    writeln!(writer, "#         max: 100")?;
+    writeln!(writer, "#         min: 0")?;
+    writeln!(writer, "#         suffix: '%'")?;
+    writeln!(writer, "#         format: '{{:.1f}}'")?;
+    writeln!(writer, "#     proper_pair_pct:")?;
+    writeln!(writer, "#         title: '% Proper Pairs'")?;
+    writeln!(
+        writer,
+        "#         description: 'Percentage of mapped reads in proper pairs'"
+    )?;
+    writeln!(writer, "#         max: 100")?;
+    writeln!(writer, "#         min: 0")?;
+    writeln!(writer, "#         suffix: '%'")?;
+    writeln!(writer, "#         format: '{{:.1f}}'")?;
+    writeln!(
+        writer,
+        "Sample\ttotal_reads\tmapped_pct\tduplicate_pct\tproper_pair_pct"
+    )?;
+    writeln!(
+        writer,
+        "{}\t{}\t{:.1}\t{:.1}\t{:.1}",
+        sample_name, result.stat_total_reads, mapped_pct, dup_pct, proper_pair_pct
+    )?;
+
+    writer
+        .flush()
+        .context("Failed to flush BAM stat MultiQC output")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::counting::CountResult;
+    use indexmap::IndexMap;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn test_output_dir() -> PathBuf {
+        let dir = PathBuf::from("tests/output_bamstat_unit");
+        let _ = fs::create_dir_all(&dir);
+        dir
+    }
+
+    fn make_test_result() -> CountResult {
+        CountResult {
+            gene_counts: IndexMap::new(),
+            total_reads_multi_dup: 10,
+            total_reads_multi_nodup: 20,
+            total_reads_unique_dup: 30,
+            total_reads_unique_nodup: 40,
+            stat_total_reads: 1000,
+            stat_assigned: 500,
+            stat_ambiguous: 50,
+            stat_no_features: 200,
+            stat_total_fragments: 800,
+            stat_total_dup: 100,
+            stat_total_multi: 150,
+            stat_unmapped: 50,
+            stat_qc_failed: 10,
+            stat_secondary: 5,
+            stat_supplementary: 15,
+            stat_non_primary_hits: 20,
+            stat_proper_pairs: 600,
+            stat_read1: 400,
+            stat_read2: 400,
+            stat_plus_strand: 450,
+            stat_minus_strand: 475,
+            stat_singletons: 20,
+            stat_mate_mapped_diff_chr: 10,
+            stat_splice_reads: 300,
+            stat_non_splice_reads: 625,
+        }
+    }
+
+    #[test]
+    fn test_write_bam_stat() {
+        let dir = test_output_dir();
+        let path = dir.join("test.bam_stat.txt");
+        let result = make_test_result();
+
+        write_bam_stat(&path, &result, "test.bam").unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("Total records:"),
+            "Missing 'Total records' header"
+        );
+        assert!(content.contains("1000"), "Missing total records count");
+        assert!(content.contains("QC failed:"), "Missing 'QC failed' header");
+        assert!(
+            content.contains("Unmapped reads:"),
+            "Missing 'Unmapped reads' header"
+        );
+        assert!(
+            content.contains("Non primary hits:"),
+            "Missing 'Non primary hits' header"
+        );
+        assert!(
+            content.contains("Splice reads:"),
+            "Missing 'Splice reads' header"
+        );
+        assert!(
+            content.contains("Reads mapped in proper pairs:"),
+            "Missing proper pairs header"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_write_bam_stat_mqc() {
+        let dir = test_output_dir();
+        let path = dir.join("test.bam_stat_mqc.txt");
+        let result = make_test_result();
+
+        write_bam_stat_mqc(&path, &result, "sample1").unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("rustqc_bamstat"),
+            "Missing MultiQC section ID"
+        );
+        assert!(
+            content.contains("generalstats"),
+            "Missing plot_type generalstats"
+        );
+        assert!(content.contains("sample1"), "Missing sample name");
+        assert!(
+            content.contains("1000"),
+            "Missing total reads in MultiQC output"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,10 @@ pub struct Config {
     /// featureCounts-compatible output configuration.
     #[serde(default)]
     pub featurecounts: FeatureCountsConfig,
+
+    /// BAM statistics output configuration.
+    #[serde(default)]
+    pub bamstat: BamStatConfig,
 }
 
 /// Configuration for dupRadar outputs.
@@ -160,6 +164,36 @@ impl Default for FeatureCountsConfig {
     }
 }
 
+/// Configuration for BAM alignment statistics outputs.
+///
+/// Controls which BAM stat output files are generated.
+/// All outputs are enabled by default.
+///
+/// Example:
+/// ```yaml
+/// bamstat:
+///   bam_stat: true
+///   multiqc_bamstat: true
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct BamStatConfig {
+    /// Write the BAM statistics text file.
+    pub bam_stat: bool,
+
+    /// Write the MultiQC general statistics file.
+    pub multiqc_bamstat: bool,
+}
+
+impl Default for BamStatConfig {
+    fn default() -> Self {
+        Self {
+            bam_stat: true,
+            multiqc_bamstat: true,
+        }
+    }
+}
+
 impl Config {
     /// Load configuration from a YAML file.
     pub fn from_file(path: &Path) -> Result<Self> {
@@ -203,6 +237,12 @@ impl Config {
     pub fn any_biotype_output(&self) -> bool {
         let fc = &self.featurecounts;
         fc.biotype_counts || fc.biotype_counts_mqc || fc.biotype_rrna_mqc
+    }
+
+    /// Returns true if any BAM stat output is enabled.
+    pub fn any_bamstat_output(&self) -> bool {
+        let bs = &self.bamstat;
+        bs.bam_stat || bs.multiqc_bamstat
     }
 
     /// Returns true if any dupRadar output is enabled.

--- a/src/counting.rs
+++ b/src/counting.rs
@@ -279,6 +279,36 @@ pub struct CountResult {
     /// Total multimapping reads
     #[allow(dead_code)]
     pub stat_total_multi: u64,
+
+    // --- BAM stat counters (RSeQC bam_stat.py equivalent) ---
+    /// Unmapped reads (BAM flag 0x4)
+    pub stat_unmapped: u64,
+    /// QC-failed reads (BAM flag 0x200)
+    pub stat_qc_failed: u64,
+    /// Secondary alignments (BAM flag 0x100)
+    pub stat_secondary: u64,
+    /// Supplementary alignments (BAM flag 0x800)
+    pub stat_supplementary: u64,
+    /// Non-primary hits (secondary + supplementary)
+    pub stat_non_primary_hits: u64,
+    /// Reads mapped in proper pairs (BAM flag 0x2)
+    pub stat_proper_pairs: u64,
+    /// Read-1 reads among mapped (BAM flag 0x40)
+    pub stat_read1: u64,
+    /// Read-2 reads among mapped (paired but not read-1)
+    pub stat_read2: u64,
+    /// Mapped reads on the forward (+) strand
+    pub stat_plus_strand: u64,
+    /// Mapped reads on the reverse (-) strand
+    pub stat_minus_strand: u64,
+    /// Singletons: mapped reads whose mate is unmapped
+    pub stat_singletons: u64,
+    /// Reads whose mate maps to a different chromosome
+    pub stat_mate_mapped_diff_chr: u64,
+    /// Spliced reads (CIGAR contains 'N' / RefSkip operation)
+    pub stat_splice_reads: u64,
+    /// Non-spliced mapped reads (no 'N' in CIGAR)
+    pub stat_non_splice_reads: u64,
 }
 
 /// Metadata stored with each interval in the cache-oblivious interval tree.
@@ -478,6 +508,21 @@ struct ChromResult {
     n_multi_nodup: u64,
     n_unique_dup: u64,
     n_unique_nodup: u64,
+
+    // BAM stat counters
+    stat_unmapped: u64,
+    stat_qc_failed: u64,
+    stat_secondary: u64,
+    stat_supplementary: u64,
+    stat_proper_pairs: u64,
+    stat_read1: u64,
+    stat_read2: u64,
+    stat_plus_strand: u64,
+    stat_minus_strand: u64,
+    stat_singletons: u64,
+    stat_mate_mapped_diff_chr: u64,
+    stat_splice_reads: u64,
+    stat_non_splice_reads: u64,
 }
 
 impl ChromResult {
@@ -498,6 +543,19 @@ impl ChromResult {
             n_multi_nodup: 0,
             n_unique_dup: 0,
             n_unique_nodup: 0,
+            stat_unmapped: 0,
+            stat_qc_failed: 0,
+            stat_secondary: 0,
+            stat_supplementary: 0,
+            stat_proper_pairs: 0,
+            stat_read1: 0,
+            stat_read2: 0,
+            stat_plus_strand: 0,
+            stat_minus_strand: 0,
+            stat_singletons: 0,
+            stat_mate_mapped_diff_chr: 0,
+            stat_splice_reads: 0,
+            stat_non_splice_reads: 0,
         }
     }
 
@@ -523,6 +581,19 @@ impl ChromResult {
         self.n_multi_nodup += other.n_multi_nodup;
         self.n_unique_dup += other.n_unique_dup;
         self.n_unique_nodup += other.n_unique_nodup;
+        self.stat_unmapped += other.stat_unmapped;
+        self.stat_qc_failed += other.stat_qc_failed;
+        self.stat_secondary += other.stat_secondary;
+        self.stat_supplementary += other.stat_supplementary;
+        self.stat_proper_pairs += other.stat_proper_pairs;
+        self.stat_read1 += other.stat_read1;
+        self.stat_read2 += other.stat_read2;
+        self.stat_plus_strand += other.stat_plus_strand;
+        self.stat_minus_strand += other.stat_minus_strand;
+        self.stat_singletons += other.stat_singletons;
+        self.stat_mate_mapped_diff_chr += other.stat_mate_mapped_diff_chr;
+        self.stat_splice_reads += other.stat_splice_reads;
+        self.stat_non_splice_reads += other.stat_non_splice_reads;
     }
 }
 
@@ -577,6 +648,20 @@ fn process_chromosome_batch(
 
             let flags = record.flags();
 
+            // Count BAM stat categories before skip filters
+            if flags & BAM_FUNMAP != 0 {
+                result.stat_unmapped += 1;
+            }
+            if flags & BAM_FQCFAIL != 0 {
+                result.stat_qc_failed += 1;
+            }
+            if flags & BAM_FSECONDARY != 0 {
+                result.stat_secondary += 1;
+            }
+            if flags & BAM_FSUPPLEMENTARY != 0 {
+                result.stat_supplementary += 1;
+            }
+
             // Skip unmapped reads
             if flags & BAM_FUNMAP != 0 {
                 continue;
@@ -621,6 +706,42 @@ fn process_chromosome_batch(
 
             let is_reverse = flags & BAM_FREVERSE != 0;
             let is_read1 = flags & BAM_FREAD1 != 0;
+
+            // BAM stat counters for mapped reads
+            if is_reverse {
+                result.stat_minus_strand += 1;
+            } else {
+                result.stat_plus_strand += 1;
+            }
+            if flags & BAM_FPAIRED != 0 {
+                if is_read1 {
+                    result.stat_read1 += 1;
+                } else {
+                    result.stat_read2 += 1;
+                }
+                if flags & BAM_FPROPER_PAIR != 0 {
+                    result.stat_proper_pairs += 1;
+                }
+                if flags & BAM_FMUNMAP != 0 {
+                    result.stat_singletons += 1;
+                } else if record.mtid() != record.tid() {
+                    result.stat_mate_mapped_diff_chr += 1;
+                }
+            }
+
+            // Splice detection: check CIGAR for RefSkip ('N') operations
+            {
+                use rust_htslib::bam::record::Cigar;
+                let has_splice = record
+                    .cigar()
+                    .iter()
+                    .any(|op| matches!(op, Cigar::RefSkip(_)));
+                if has_splice {
+                    result.stat_splice_reads += 1;
+                } else {
+                    result.stat_non_splice_reads += 1;
+                }
+            }
 
             // Get the chromosome name
             let rec_tid = record.tid();
@@ -969,6 +1090,20 @@ pub fn count_reads(
 
             let flags = record.flags();
 
+            // Count BAM stat categories before skip filters
+            if flags & BAM_FUNMAP != 0 {
+                result.stat_unmapped += 1;
+            }
+            if flags & BAM_FQCFAIL != 0 {
+                result.stat_qc_failed += 1;
+            }
+            if flags & BAM_FSECONDARY != 0 {
+                result.stat_secondary += 1;
+            }
+            if flags & BAM_FSUPPLEMENTARY != 0 {
+                result.stat_supplementary += 1;
+            }
+
             if flags & BAM_FUNMAP != 0 {
                 continue;
             }
@@ -1004,6 +1139,40 @@ pub fn count_reads(
 
             let is_reverse = flags & BAM_FREVERSE != 0;
             let is_read1 = flags & BAM_FREAD1 != 0;
+
+            if is_reverse {
+                result.stat_minus_strand += 1;
+            } else {
+                result.stat_plus_strand += 1;
+            }
+            if flags & BAM_FPAIRED != 0 {
+                if is_read1 {
+                    result.stat_read1 += 1;
+                } else {
+                    result.stat_read2 += 1;
+                }
+                if flags & BAM_FPROPER_PAIR != 0 {
+                    result.stat_proper_pairs += 1;
+                }
+                if flags & BAM_FMUNMAP != 0 {
+                    result.stat_singletons += 1;
+                } else if record.mtid() != record.tid() {
+                    result.stat_mate_mapped_diff_chr += 1;
+                }
+            }
+
+            {
+                use rust_htslib::bam::record::Cigar;
+                let has_splice = record
+                    .cigar()
+                    .iter()
+                    .any(|op| matches!(op, Cigar::RefSkip(_)));
+                if has_splice {
+                    result.stat_splice_reads += 1;
+                } else {
+                    result.stat_non_splice_reads += 1;
+                }
+            }
 
             let tid = record.tid();
             if tid < 0 || tid as usize >= tid_to_name.len() {
@@ -1352,6 +1521,20 @@ pub fn count_reads(
         stat_total_fragments: merged.total_fragments,
         stat_total_dup: merged.total_dup,
         stat_total_multi: merged.total_multi,
+        stat_unmapped: merged.stat_unmapped,
+        stat_qc_failed: merged.stat_qc_failed,
+        stat_secondary: merged.stat_secondary,
+        stat_supplementary: merged.stat_supplementary,
+        stat_proper_pairs: merged.stat_proper_pairs,
+        stat_read1: merged.stat_read1,
+        stat_read2: merged.stat_read2,
+        stat_plus_strand: merged.stat_plus_strand,
+        stat_minus_strand: merged.stat_minus_strand,
+        stat_singletons: merged.stat_singletons,
+        stat_mate_mapped_diff_chr: merged.stat_mate_mapped_diff_chr,
+        stat_splice_reads: merged.stat_splice_reads,
+        stat_non_splice_reads: merged.stat_non_splice_reads,
+        stat_non_primary_hits: merged.stat_secondary + merged.stat_supplementary,
     })
 }
 

--- a/src/featurecounts.rs
+++ b/src/featurecounts.rs
@@ -328,6 +328,20 @@ mod tests {
             stat_total_fragments: 200,
             stat_total_dup: 0,
             stat_total_multi: 0,
+            stat_unmapped: 0,
+            stat_qc_failed: 0,
+            stat_secondary: 0,
+            stat_supplementary: 0,
+            stat_non_primary_hits: 0,
+            stat_proper_pairs: 0,
+            stat_read1: 0,
+            stat_read2: 0,
+            stat_plus_strand: 0,
+            stat_minus_strand: 0,
+            stat_singletons: 0,
+            stat_mate_mapped_diff_chr: 0,
+            stat_splice_reads: 0,
+            stat_non_splice_reads: 0,
         };
 
         let biotypes = aggregate_biotype_counts(&genes, &count_result, "gene_biotype");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 //! level in RNA-Seq datasets. It also produces featureCounts-compatible output
 //! files and biotype count summaries in a single pass.
 
+mod bamstat;
 mod cli;
 mod config;
 mod counting;
@@ -500,6 +501,28 @@ fn process_single_bam(
                     mqc_rrna_path.display()
                 );
             }
+        }
+    }
+
+    // === BAM stat outputs ===
+    if config.any_bamstat_output() {
+        if config.bamstat.bam_stat {
+            let bamstat_path = outdir.join(format!("{}.bam_stat.txt", bam_stem));
+            bamstat::write_bam_stat(&bamstat_path, &count_result, bam_path)?;
+            info!(
+                "[{}] BAM stats written to {}",
+                bam_stem,
+                bamstat_path.display()
+            );
+        }
+        if config.bamstat.multiqc_bamstat {
+            let mqc_path = outdir.join(format!("{}.bam_stat_mqc.txt", bam_stem));
+            bamstat::write_bam_stat_mqc(&mqc_path, &count_result, bam_stem)?;
+            info!(
+                "[{}] BAM stat MultiQC file written to {}",
+                bam_stem,
+                mqc_path.display()
+            );
         }
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -280,6 +280,8 @@ fn test_all_output_files_generated() {
         "test_expressionHist.svg",
         "test_dup_intercept_mqc.txt",
         "test_duprateExpDensCurve_mqc.txt",
+        "test.bam_stat.txt",
+        "test.bam_stat_mqc.txt",
     ];
 
     for file in &expected_files {
@@ -479,6 +481,153 @@ fn test_count_values_exact() {
 }
 
 // ===================================================================
+// BAM stat tests
+// ===================================================================
+
+/// Verify the BAM stat output file is generated and contains expected lines.
+#[test]
+fn test_bam_stat_output() {
+    let outdir = "tests/output_integration_bamstat";
+    let _ = fs::remove_dir_all(outdir);
+    fs::create_dir_all(outdir).unwrap();
+
+    let output = run_rustqc(outdir);
+    assert!(
+        output.status.success(),
+        "rustqc failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stat_path = format!("{}/test.bam_stat.txt", outdir);
+    assert!(
+        Path::new(&stat_path).exists(),
+        "Missing bam_stat output file"
+    );
+
+    let content = fs::read_to_string(&stat_path).unwrap();
+
+    // Check that expected header and key lines are present
+    assert!(
+        content.contains("RustQC bam_stat"),
+        "Missing RustQC header in bam_stat output"
+    );
+    assert!(
+        content.contains("Total records:"),
+        "Missing 'Total records' line"
+    );
+    assert!(
+        content.contains("Unmapped reads:"),
+        "Missing 'Unmapped reads' line"
+    );
+    assert!(content.contains("QC failed:"), "Missing 'QC failed' line");
+    assert!(
+        content.contains("Non primary hits:"),
+        "Missing 'Non primary hits' line"
+    );
+    assert!(
+        content.contains("Splice reads:"),
+        "Missing 'Splice reads' line"
+    );
+    assert!(
+        content.contains("Non-splice reads:"),
+        "Missing 'Non-splice reads' line"
+    );
+
+    // Parse Total records and verify it's a positive number
+    let total_line = content
+        .lines()
+        .find(|l| l.starts_with("Total records:"))
+        .expect("No 'Total records' line found");
+    let total: u64 = total_line
+        .split_whitespace()
+        .last()
+        .unwrap()
+        .parse()
+        .expect("Total records should be numeric");
+    assert!(total > 0, "Total records should be > 0, got {}", total);
+
+    // Cleanup
+    let _ = fs::remove_dir_all(outdir);
+}
+
+/// Verify the BAM stat MultiQC output file format.
+#[test]
+fn test_bam_stat_mqc_format() {
+    let outdir = "tests/output_integration_bamstat_mqc";
+    let _ = fs::remove_dir_all(outdir);
+    fs::create_dir_all(outdir).unwrap();
+
+    let output = run_rustqc(outdir);
+    assert!(output.status.success());
+
+    let mqc_path = format!("{}/test.bam_stat_mqc.txt", outdir);
+    let content = fs::read_to_string(&mqc_path).unwrap();
+
+    // Should have YAML comment header
+    assert!(
+        content.starts_with('#'),
+        "MultiQC file should start with YAML header comments"
+    );
+
+    // Skip comment lines, verify data
+    let data_lines: Vec<&str> = content.lines().filter(|l| !l.starts_with('#')).collect();
+    assert!(
+        data_lines.len() >= 2,
+        "MultiQC bamstat file should have header + data"
+    );
+
+    // Header should contain expected column names
+    assert!(
+        data_lines[0].contains("Sample"),
+        "Missing 'Sample' in MQC header"
+    );
+    assert!(
+        data_lines[0].contains("total_reads"),
+        "Missing 'total_reads' in MQC header"
+    );
+
+    // Cleanup
+    let _ = fs::remove_dir_all(outdir);
+}
+
+/// Verify SAM and BAM inputs produce identical bam_stat output.
+#[test]
+fn test_bam_stat_sam_vs_bam() {
+    let outdir_bam = "tests/output_bamstat_sam_bam";
+    let outdir_sam = "tests/output_bamstat_sam_sam";
+    let _ = fs::remove_dir_all(outdir_bam);
+    let _ = fs::remove_dir_all(outdir_sam);
+    fs::create_dir_all(outdir_bam).unwrap();
+    fs::create_dir_all(outdir_sam).unwrap();
+
+    let out_bam = run_rustqc_with_input(outdir_bam, "tests/data/test.bam");
+    assert!(out_bam.status.success());
+
+    let out_sam = run_rustqc_with_input(outdir_sam, "tests/data/test.sam");
+    assert!(out_sam.status.success());
+
+    let bam_stat = fs::read_to_string(format!("{}/test.bam_stat.txt", outdir_bam)).unwrap();
+    let sam_stat = fs::read_to_string(format!("{}/test.bam_stat.txt", outdir_sam)).unwrap();
+
+    // Strip the "# Input file:" line since BAM/SAM paths differ
+    let strip_input_line = |s: &str| -> String {
+        s.lines()
+            .filter(|l| !l.starts_with("# Input file:"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    assert_eq!(
+        strip_input_line(&bam_stat),
+        strip_input_line(&sam_stat),
+        "BAM and SAM bam_stat output should be identical (ignoring input path)"
+    );
+
+    // Cleanup
+    let _ = fs::remove_dir_all(outdir_bam);
+    let _ = fs::remove_dir_all(outdir_sam);
+}
+
+// ===================================================================
 // Multi-BAM tests
 // ===================================================================
 
@@ -505,6 +654,10 @@ fn test_multiple_bam_files() {
         "test_copy_duprateExpDens.png",
         "test_copy_duprateExpBoxplot.png",
         "test_copy_expressionHist.png",
+        "test.bam_stat.txt",
+        "test.bam_stat_mqc.txt",
+        "test_copy.bam_stat.txt",
+        "test_copy.bam_stat_mqc.txt",
     ];
 
     for filename in &expected_files {


### PR DESCRIPTION
## Summary

Adds RSeQC `bam_stat.py`-compatible BAM alignment statistics, collected during the existing single-pass BAM traversal with **zero additional I/O cost**.

This is the first of several planned tool replacements (P0 priority) that leverage RustQC's existing BAM pass to eliminate separate Python/Java tool invocations in nf-core/rnaseq.

## New Outputs

### `{sample}.bam_stat.txt`
RSeQC-compatible alignment statistics including:
- Total records, QC-failed, duplicates
- Secondary / supplementary / non-primary hits
- Unmapped reads
- Unique vs multi-mapped reads
- Read-1 / Read-2 counts
- Plus / minus strand distribution
- Splice / non-splice read counts
- Proper pairs, singletons, mate-mapped-different-chromosome

### `{sample}.bam_stat_mqc.txt`
MultiQC general stats integration with key metrics (total reads, mapped %, duplicate %, proper pair %).

## Implementation

- **13 new counters** added to `ChromResult`/`CountResult` in `counting.rs`, incremented during the existing BAM traversal (both parallel and single-threaded paths)
- **New `bamstat.rs` module** with `write_bam_stat()` and `write_bam_stat_mqc()` functions
- **`BamStatConfig`** in `config.rs` — both outputs individually toggleable via YAML config, all default to enabled
- **Integration tests**: output format validation, MultiQC format, SAM/BAM parity

## Configuration

Outputs can be toggled in the YAML config:
```yaml
bamstat:
  bam_stat: true           # bam_stat.txt
  multiqc_bamstat: true    # MultiQC general stats
```

## What This Replaces

| Tool | Language | Speed | RustQC |
|------|----------|-------|--------|
| RSeQC `bam_stat.py` | Python | Separate BAM pass | Same pass, zero cost |

## Checklist
- [x] `cargo test` — all 14 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Unit tests in `bamstat.rs`
- [x] Integration tests (format, MultiQC, SAM/BAM parity)
- [x] Documentation (module docs, public item docs)