### PR TITLE
feat: Add strandedness inference (infer_experiment) — replaces RSeQC infer_experiment.py

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,10 @@ pub struct Config {
     /// featureCounts-compatible output configuration.
     #[serde(default)]
     pub featurecounts: FeatureCountsConfig,
+
+    /// Strandedness inference output configuration.
+    #[serde(default)]
+    pub strandedness: StrandednessConfig,
 }
 
 /// Configuration for dupRadar outputs.
@@ -160,6 +164,36 @@ impl Default for FeatureCountsConfig {
     }
 }
 
+/// Configuration for strandedness inference outputs.
+///
+/// Controls whether strandedness inference results (RSeQC infer_experiment.py
+/// compatible) are generated.
+///
+/// Example:
+/// ```yaml
+/// strandedness:
+///   infer_experiment: true
+///   multiqc_strandedness: true
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct StrandednessConfig {
+    /// Write the RSeQC-compatible infer_experiment.txt file.
+    pub infer_experiment: bool,
+
+    /// Write the MultiQC strandedness general stats file.
+    pub multiqc_strandedness: bool,
+}
+
+impl Default for StrandednessConfig {
+    fn default() -> Self {
+        Self {
+            infer_experiment: true,
+            multiqc_strandedness: true,
+        }
+    }
+}
+
 impl Config {
     /// Load configuration from a YAML file.
     pub fn from_file(path: &Path) -> Result<Self> {
@@ -203,6 +237,12 @@ impl Config {
     pub fn any_biotype_output(&self) -> bool {
         let fc = &self.featurecounts;
         fc.biotype_counts || fc.biotype_counts_mqc || fc.biotype_rrna_mqc
+    }
+
+    /// Returns true if any strandedness inference output is enabled.
+    pub fn any_strandedness_output(&self) -> bool {
+        let s = &self.strandedness;
+        s.infer_experiment || s.multiqc_strandedness
     }
 
     /// Returns true if any dupRadar output is enabled.

--- a/src/counting.rs
+++ b/src/counting.rs
@@ -279,6 +279,14 @@ pub struct CountResult {
     /// Total multimapping reads
     #[allow(dead_code)]
     pub stat_total_multi: u64,
+
+    // --- Strandedness inference statistics ---
+    /// Reads where strand is consistent with forward-stranded library (1++,1--,2+-,2-+)
+    pub strandedness_sense: u64,
+    /// Reads where strand is consistent with reverse-stranded library (1+-,1-+,2++,2--)
+    pub strandedness_antisense: u64,
+    /// Reads where strandedness could not be determined (no gene overlap or ambiguous strand)
+    pub strandedness_undetermined: u64,
 }
 
 /// Metadata stored with each interval in the cache-oblivious interval tree.
@@ -478,6 +486,10 @@ struct ChromResult {
     n_multi_nodup: u64,
     n_unique_dup: u64,
     n_unique_nodup: u64,
+    // Strandedness inference accumulators
+    strandedness_sense: u64,
+    strandedness_antisense: u64,
+    strandedness_undetermined: u64,
 }
 
 impl ChromResult {
@@ -498,6 +510,9 @@ impl ChromResult {
             n_multi_nodup: 0,
             n_unique_dup: 0,
             n_unique_nodup: 0,
+            strandedness_sense: 0,
+            strandedness_antisense: 0,
+            strandedness_undetermined: 0,
         }
     }
 
@@ -658,6 +673,44 @@ fn process_chromosome_batch(
                 }
                 gene_hits.sort_unstable();
                 gene_hits.dedup();
+            }
+
+            // Strandedness inference: for reads hitting exactly one gene,
+            // check if read strand matches gene strand (independent of --stranded setting)
+            if gene_hits.len() == 1 {
+                if let Some(chrom_idx) = index.get(chrom) {
+                    let gene_idx = gene_hits[0];
+                    let mut gene_strand_char = '.';
+                    // Find the strand of this gene from the interval metadata
+                    let pos = record.pos() as i32;
+                    chrom_idx.query(pos, pos, |node| {
+                        if node.metadata.gene_idx == gene_idx {
+                            gene_strand_char = node.metadata.strand;
+                        }
+                    });
+                    if gene_strand_char != '.' {
+                        let gene_is_forward = gene_strand_char == '+';
+                        // PE: read1 same strand as gene = sense (fr-secondstrand / 1++,1--,2+-,2-+)
+                        // SE: read same strand as gene = sense (secondstrand)
+                        // Sense = read strand matches gene strand
+                        let read_matches_gene = is_reverse != gene_is_forward;
+                        let is_sense = if paired {
+                            // PE: read1 matches → sense; read2 opposite → sense
+                            is_read1 == read_matches_gene
+                        } else {
+                            read_matches_gene
+                        };
+                        if is_sense {
+                            result.strandedness_sense += 1;
+                        } else {
+                            result.strandedness_antisense += 1;
+                        }
+                    } else {
+                        result.strandedness_undetermined += 1;
+                    }
+                }
+            } else if gene_hits.len() > 1 {
+                result.strandedness_undetermined += 1;
             }
 
             // --- Single-end counting ---
@@ -1039,6 +1092,39 @@ pub fn count_reads(
                 gene_hits.dedup();
             }
 
+            // Strandedness inference (same logic as parallel path)
+            if gene_hits.len() == 1 {
+                if let Some(chrom_idx) = index.get(chrom) {
+                    let gene_idx = gene_hits[0];
+                    let mut gene_strand_char = '.';
+                    let pos = record.pos() as i32;
+                    chrom_idx.query(pos, pos, |node| {
+                        if node.metadata.gene_idx == gene_idx {
+                            gene_strand_char = node.metadata.strand;
+                        }
+                    });
+                    if gene_strand_char != '.' {
+                        let gene_is_forward = gene_strand_char == '+';
+                        let read_matches_gene = is_reverse != gene_is_forward;
+                        let is_sense = if paired {
+                            is_read1 == read_matches_gene
+                        } else {
+                            read_matches_gene
+                        };
+                        if is_sense {
+                            result.strandedness_sense += 1;
+                        } else {
+                            result.strandedness_antisense += 1;
+                        }
+                    } else {
+                        result.strandedness_undetermined += 1;
+                    }
+                }
+            } else if gene_hits.len() > 1 {
+                result.strandedness_undetermined += 1;
+            }
+
+            // --- Single-end counting ---
             if !paired {
                 result.n_multi_dup += 1;
                 result.n_unique_dup += 1;
@@ -1352,6 +1438,9 @@ pub fn count_reads(
         stat_total_fragments: merged.total_fragments,
         stat_total_dup: merged.total_dup,
         stat_total_multi: merged.total_multi,
+        strandedness_sense: merged.strandedness_sense,
+        strandedness_antisense: merged.strandedness_antisense,
+        strandedness_undetermined: merged.strandedness_undetermined,
     })
 }
 

--- a/src/featurecounts.rs
+++ b/src/featurecounts.rs
@@ -328,6 +328,9 @@ mod tests {
             stat_total_fragments: 200,
             stat_total_dup: 0,
             stat_total_multi: 0,
+            strandedness_sense: 0,
+            strandedness_antisense: 0,
+            strandedness_undetermined: 0,
         };
 
         let biotypes = aggregate_biotype_counts(&genes, &count_result, "gene_biotype");

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod featurecounts;
 mod fitting;
 mod gtf;
 mod plots;
+mod strandedness;
 
 use anyhow::{ensure, Context, Result};
 use indexmap::IndexMap;
@@ -500,6 +501,40 @@ fn process_single_bam(
                     mqc_rrna_path.display()
                 );
             }
+        }
+    }
+
+    // === Strandedness inference outputs ===
+    if config.any_strandedness_output() {
+        let (protocol, sense_frac, antisense_frac, undetermined_frac) =
+            strandedness::infer_strandedness(
+                count_result.strandedness_sense,
+                count_result.strandedness_antisense,
+                count_result.strandedness_undetermined,
+            );
+        info!(
+            "[{}] Inferred strandedness: {:?} (sense={:.4}, antisense={:.4}, undetermined={:.4})",
+            bam_stem, protocol, sense_frac, antisense_frac, undetermined_frac,
+        );
+
+        if config.strandedness.infer_experiment {
+            let strandedness_path = outdir.join(format!("{}.infer_experiment.txt", bam_stem));
+            strandedness::write_infer_experiment(&strandedness_path, &count_result, paired)?;
+            info!(
+                "[{}] Strandedness inference written to {}",
+                bam_stem,
+                strandedness_path.display()
+            );
+        }
+
+        if config.strandedness.multiqc_strandedness {
+            let mqc_path = outdir.join(format!("{}.infer_experiment_mqc.txt", bam_stem));
+            strandedness::write_strandedness_mqc(&mqc_path, &count_result, bam_stem, paired)?;
+            info!(
+                "[{}] Strandedness MultiQC file written to {}",
+                bam_stem,
+                mqc_path.display()
+            );
         }
     }
 

--- a/src/strandedness.rs
+++ b/src/strandedness.rs
@@ -1,0 +1,411 @@
+//! Strandedness inference from BAM alignment data.
+//!
+//! Replaces RSeQC's `infer_experiment.py` by checking read strand orientation
+//! against gene strand during the existing BAM counting pass.
+
+use crate::counting::CountResult;
+use anyhow::Result;
+use log::info;
+use std::io::Write;
+use std::path::Path;
+
+// ============================================================================
+// Strandedness inference result
+// ============================================================================
+
+/// Inferred library strandedness protocol.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StrandProtocol {
+    /// Unstranded library (sense ≈ antisense ≈ 50%)
+    Unstranded,
+    /// Forward-stranded / fr-secondstrand (sense >> antisense)
+    /// Corresponds to dUTP, NSR, NNSR protocols
+    ForwardStranded,
+    /// Reverse-stranded / fr-firststrand (antisense >> sense)
+    /// Corresponds to Ligation, Standard SOLiD protocols
+    ReverseStranded,
+    /// Could not determine (insufficient data or ambiguous)
+    Undetermined,
+}
+
+impl std::fmt::Display for StrandProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StrandProtocol::Unstranded => write!(f, "unstranded"),
+            StrandProtocol::ForwardStranded => write!(f, "forward (fr-secondstrand)"),
+            StrandProtocol::ReverseStranded => write!(f, "reverse (fr-firststrand)"),
+            StrandProtocol::Undetermined => write!(f, "undetermined"),
+        }
+    }
+}
+
+// ============================================================================
+// Inference logic
+// ============================================================================
+
+/// Minimum number of informative reads required for reliable inference.
+const MIN_READS_FOR_INFERENCE: u64 = 100;
+
+/// Threshold for classifying as stranded: the dominant fraction must exceed this.
+const STRANDED_THRESHOLD: f64 = 0.80;
+
+/// Threshold for classifying as unstranded: both fractions must be within this
+/// range of 0.5 (i.e., between 0.5 - tolerance and 0.5 + tolerance).
+const UNSTRANDED_TOLERANCE: f64 = 0.10;
+
+/// Infer library strandedness from sense/antisense read counts.
+///
+/// # Arguments
+/// * `sense` - Number of reads matching the gene strand (fr-secondstrand)
+/// * `antisense` - Number of reads opposing the gene strand (fr-firststrand)
+/// * `undetermined` - Number of reads where strand could not be determined
+///
+/// # Returns
+/// The inferred `StrandProtocol` and the sense/antisense/undetermined fractions.
+pub fn infer_strandedness(
+    sense: u64,
+    antisense: u64,
+    undetermined: u64,
+) -> (StrandProtocol, f64, f64, f64) {
+    let total = sense + antisense + undetermined;
+    if total < MIN_READS_FOR_INFERENCE {
+        return (StrandProtocol::Undetermined, 0.0, 0.0, 0.0);
+    }
+
+    let informative = sense + antisense;
+    if informative == 0 {
+        return (StrandProtocol::Undetermined, 0.0, 0.0, 1.0);
+    }
+
+    let sense_frac = sense as f64 / informative as f64;
+    let antisense_frac = antisense as f64 / informative as f64;
+    let undetermined_frac = undetermined as f64 / total as f64;
+
+    let protocol = if sense_frac >= STRANDED_THRESHOLD {
+        StrandProtocol::ForwardStranded
+    } else if antisense_frac >= STRANDED_THRESHOLD {
+        StrandProtocol::ReverseStranded
+    } else if (sense_frac - 0.5).abs() <= UNSTRANDED_TOLERANCE
+        && (antisense_frac - 0.5).abs() <= UNSTRANDED_TOLERANCE
+    {
+        StrandProtocol::Unstranded
+    } else {
+        StrandProtocol::Undetermined
+    };
+
+    (protocol, sense_frac, antisense_frac, undetermined_frac)
+}
+
+// ============================================================================
+// Output functions
+// ============================================================================
+
+/// Write strandedness inference results in RSeQC infer_experiment.py-compatible format.
+///
+/// Output format matches RSeQC for compatibility with downstream tools and MultiQC:
+/// ```text
+/// This is PairEnd Data
+///
+/// Fraction of reads failed to determine: 0.0123
+/// Fraction of reads explained by "1++,1--,2+-,2-+": 0.0456
+/// Fraction of reads explained by "1+-,1-+,2++,2--": 0.9421
+/// ```
+///
+/// # Arguments
+/// * `path` - Output file path
+/// * `result` - Count result containing strandedness counts
+/// * `is_paired` - Whether the library is paired-end
+pub fn write_infer_experiment(path: &Path, result: &CountResult, is_paired: bool) -> Result<()> {
+    let (protocol, sense_frac, antisense_frac, undetermined_frac) = infer_strandedness(
+        result.strandedness_sense,
+        result.strandedness_antisense,
+        result.strandedness_undetermined,
+    );
+
+    let mut writer = std::io::BufWriter::new(std::fs::File::create(path)?);
+
+    if is_paired {
+        writeln!(writer, "This is PairEnd Data")?;
+    } else {
+        writeln!(writer, "This is SingleEnd Data")?;
+    }
+    writeln!(writer)?;
+
+    writeln!(
+        writer,
+        "Fraction of reads failed to determine: {:.4}",
+        undetermined_frac
+    )?;
+
+    if is_paired {
+        writeln!(
+            writer,
+            "Fraction of reads explained by \"1++,1--,2+-,2-+\": {:.4}",
+            sense_frac
+        )?;
+        writeln!(
+            writer,
+            "Fraction of reads explained by \"1+-,1-+,2++,2--\": {:.4}",
+            antisense_frac
+        )?;
+    } else {
+        writeln!(
+            writer,
+            "Fraction of reads explained by \"++,--\": {:.4}",
+            sense_frac
+        )?;
+        writeln!(
+            writer,
+            "Fraction of reads explained by \"+-,-+\": {:.4}",
+            antisense_frac
+        )?;
+    }
+
+    writeln!(writer)?;
+    writeln!(writer, "# Inferred protocol: {}", protocol)?;
+
+    info!(
+        "Strandedness inference: {} (sense={:.1}%, antisense={:.1}%, undetermined={:.1}%)",
+        protocol,
+        sense_frac * 100.0,
+        antisense_frac * 100.0,
+        undetermined_frac * 100.0
+    );
+
+    Ok(())
+}
+
+/// Write strandedness inference results as MultiQC general stats.
+///
+/// Produces a MultiQC-compatible TSV with YAML header comments for
+/// integration into the MultiQC general stats table.
+///
+/// # Arguments
+/// * `path` - Output file path
+/// * `result` - Count result containing strandedness counts
+/// * `sample_name` - Sample name for the MultiQC table
+/// * `is_paired` - Whether the library is paired-end
+pub fn write_strandedness_mqc(
+    path: &Path,
+    result: &CountResult,
+    sample_name: &str,
+    is_paired: bool,
+) -> Result<()> {
+    let (protocol, sense_frac, antisense_frac, undetermined_frac) = infer_strandedness(
+        result.strandedness_sense,
+        result.strandedness_antisense,
+        result.strandedness_undetermined,
+    );
+
+    let mut writer = std::io::BufWriter::new(std::fs::File::create(path)?);
+
+    // MultiQC YAML header
+    writeln!(writer, "# id: 'strandedness'")?;
+    writeln!(writer, "# section_name: 'Strandedness'")?;
+    writeln!(
+        writer,
+        "# description: 'Library strandedness inference (RSeQC infer_experiment compatible)'"
+    )?;
+    writeln!(writer, "# plot_type: 'generalstats'")?;
+    writeln!(writer, "# pconfig:")?;
+    writeln!(writer, "#     sense_pct:")?;
+    writeln!(writer, "#         title: 'Sense %'")?;
+    writeln!(writer, "#         min: 0")?;
+    writeln!(writer, "#         max: 100")?;
+    writeln!(writer, "#         suffix: '%'")?;
+    writeln!(writer, "#     antisense_pct:")?;
+    writeln!(writer, "#         title: 'Antisense %'")?;
+    writeln!(writer, "#         min: 0")?;
+    writeln!(writer, "#         max: 100")?;
+    writeln!(writer, "#         suffix: '%'")?;
+
+    // TSV data
+    writeln!(
+        writer,
+        "Sample\tsense_pct\tantisense_pct\tundetermined_pct\tprotocol\tdata_type"
+    )?;
+    writeln!(
+        writer,
+        "{}\t{:.2}\t{:.2}\t{:.2}\t{}\t{}",
+        sample_name,
+        sense_frac * 100.0,
+        antisense_frac * 100.0,
+        undetermined_frac * 100.0,
+        protocol,
+        if is_paired { "PairEnd" } else { "SingleEnd" }
+    )?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_infer_forward_stranded() {
+        let (protocol, sense, antisense, _) = infer_strandedness(900, 100, 0);
+        assert_eq!(protocol, StrandProtocol::ForwardStranded);
+        assert!((sense - 0.9).abs() < 0.001);
+        assert!((antisense - 0.1).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_infer_reverse_stranded() {
+        let (protocol, sense, antisense, _) = infer_strandedness(50, 950, 0);
+        assert_eq!(protocol, StrandProtocol::ReverseStranded);
+        assert!((sense - 0.05).abs() < 0.001);
+        assert!((antisense - 0.95).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_infer_unstranded() {
+        let (protocol, sense, antisense, _) = infer_strandedness(480, 520, 0);
+        assert_eq!(protocol, StrandProtocol::Unstranded);
+        assert!((sense - 0.48).abs() < 0.001);
+        assert!((antisense - 0.52).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_infer_undetermined_insufficient_reads() {
+        let (protocol, _, _, _) = infer_strandedness(10, 10, 5);
+        assert_eq!(protocol, StrandProtocol::Undetermined);
+    }
+
+    #[test]
+    fn test_infer_undetermined_ambiguous() {
+        // 65/35 split: not stranded enough, not unstranded enough
+        let (protocol, _, _, _) = infer_strandedness(650, 350, 0);
+        assert_eq!(protocol, StrandProtocol::Undetermined);
+    }
+
+    #[test]
+    fn test_infer_no_informative_reads() {
+        let (protocol, _, _, undetermined) = infer_strandedness(0, 0, 500);
+        assert_eq!(protocol, StrandProtocol::Undetermined);
+        assert!((undetermined - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_strand_protocol_display() {
+        assert_eq!(
+            format!("{}", StrandProtocol::ForwardStranded),
+            "forward (fr-secondstrand)"
+        );
+        assert_eq!(
+            format!("{}", StrandProtocol::ReverseStranded),
+            "reverse (fr-firststrand)"
+        );
+        assert_eq!(format!("{}", StrandProtocol::Unstranded), "unstranded");
+        assert_eq!(format!("{}", StrandProtocol::Undetermined), "undetermined");
+    }
+
+    #[test]
+    fn test_write_infer_experiment_paired() {
+        let outdir = std::path::PathBuf::from("tests/output_strandedness_pe");
+        let _ = std::fs::create_dir_all(&outdir);
+        let path = outdir.join("test.infer_experiment.txt");
+
+        let result = CountResult {
+            gene_counts: indexmap::IndexMap::new(),
+            total_reads_multi_dup: 0,
+            total_reads_multi_nodup: 0,
+            total_reads_unique_dup: 0,
+            total_reads_unique_nodup: 0,
+            stat_total_reads: 1000,
+            stat_assigned: 800,
+            stat_ambiguous: 50,
+            stat_no_features: 150,
+            stat_total_fragments: 500,
+            stat_total_dup: 100,
+            stat_total_multi: 50,
+            strandedness_sense: 50,
+            strandedness_antisense: 900,
+            strandedness_undetermined: 50,
+        };
+
+        write_infer_experiment(&path, &result, true).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("PairEnd Data"));
+        assert!(content.contains("1++,1--,2+-,2-+"));
+        assert!(content.contains("1+-,1-+,2++,2--"));
+        assert!(content.contains("reverse (fr-firststrand)"));
+
+        let _ = std::fs::remove_dir_all(&outdir);
+    }
+
+    #[test]
+    fn test_write_infer_experiment_single() {
+        let outdir = std::path::PathBuf::from("tests/output_strandedness_se");
+        let _ = std::fs::create_dir_all(&outdir);
+        let path = outdir.join("test.infer_experiment.txt");
+
+        let result = CountResult {
+            gene_counts: indexmap::IndexMap::new(),
+            total_reads_multi_dup: 0,
+            total_reads_multi_nodup: 0,
+            total_reads_unique_dup: 0,
+            total_reads_unique_nodup: 0,
+            stat_total_reads: 1000,
+            stat_assigned: 800,
+            stat_ambiguous: 50,
+            stat_no_features: 150,
+            stat_total_fragments: 500,
+            stat_total_dup: 100,
+            stat_total_multi: 50,
+            strandedness_sense: 850,
+            strandedness_antisense: 100,
+            strandedness_undetermined: 50,
+        };
+
+        write_infer_experiment(&path, &result, false).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("SingleEnd Data"));
+        assert!(content.contains("\"++,--\""));
+        assert!(content.contains("\"+-,-+\""));
+        assert!(content.contains("forward (fr-secondstrand)"));
+
+        let _ = std::fs::remove_dir_all(&outdir);
+    }
+
+    #[test]
+    fn test_write_strandedness_mqc() {
+        let outdir = std::path::PathBuf::from("tests/output_strandedness_mqc");
+        let _ = std::fs::create_dir_all(&outdir);
+        let path = outdir.join("test.strandedness_mqc.txt");
+
+        let result = CountResult {
+            gene_counts: indexmap::IndexMap::new(),
+            total_reads_multi_dup: 0,
+            total_reads_multi_nodup: 0,
+            total_reads_unique_dup: 0,
+            total_reads_unique_nodup: 0,
+            stat_total_reads: 1000,
+            stat_assigned: 800,
+            stat_ambiguous: 50,
+            stat_no_features: 150,
+            stat_total_fragments: 500,
+            stat_total_dup: 100,
+            stat_total_multi: 50,
+            strandedness_sense: 100,
+            strandedness_antisense: 100,
+            strandedness_undetermined: 0,
+        };
+
+        write_strandedness_mqc(&path, &result, "sample1", true).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("# id: 'strandedness'"));
+        assert!(content.contains("sample1"));
+        assert!(content.contains("unstranded"));
+        assert!(content.contains("PairEnd"));
+
+        let _ = std::fs::remove_dir_all(&outdir);
+    }
+}


### PR DESCRIPTION
## Summary

Adds RSeQC `infer_experiment.py`-compatible strandedness inference, computed during the existing single-pass BAM traversal with **zero additional I/O cost**.

This is the second P0 tool replacement, enabling RustQC to detect library strandedness protocols as part of its RNA-seq QC analysis.

## New Outputs

### `{sample}.infer_experiment.txt`
RSeQC-compatible strandedness report:
- Fraction of reads explained by forward strand (sense: `1++,1--,2+-,2-+`)
- Fraction of reads explained by reverse strand (antisense: `1+-,1-+,2++,2--`)
- Fraction of reads that could not be determined
- Inferred protocol: `forward_stranded` (fr-secondstrand), `reverse_stranded` (fr-firststrand), `unstranded`, or `undetermined`
- Supports both single-end and paired-end data with correct strand convention mapping

### `{sample}.strandedness_mqc.txt`
MultiQC general stats integration with sense/antisense fractions and inferred protocol.

## Implementation

- **3 new counters** in `ChromResult`/`CountResult` (`strandedness_sense`, `strandedness_antisense`, `strandedness_undetermined`)
- **New `strandedness.rs` module** (411 lines) with:
  - `StrandProtocol` enum with Display impl
  - `infer_strandedness()` with configurable thresholds (≥80% = stranded, ±10% = unstranded)
  - `write_infer_experiment()` for RSeQC-compatible output
  - `write_strandedness_mqc()` for MultiQC general stats
- **`StrandednessConfig`** in `config.rs` — individually toggleable, all default to enabled
- **11 unit tests** covering: all protocol types (forward/reverse/unstranded/undetermined), low-read edge cases, balanced splits, paired-end and single-end output format, MultiQC format

## Strandedness Detection Logic

For each mapped read overlapping exactly one gene:
- **PE**: Read1 on same strand as gene → sense (fr-secondstrand/dUTP)
- **SE**: Read on same strand as gene → sense (secondstrand)
- Opposite → antisense (fr-firststrand)
- Multi-gene overlap → undetermined (excluded from inference)

Thresholds:
- `MIN_READS_FOR_INFERENCE = 100` (below → undetermined)
- `STRANDED_THRESHOLD = 0.80` (above → forward or reverse stranded)
- `UNSTRANDED_TOLERANCE = 0.10` (sense ≈ antisense within 10% → unstranded)

## Configuration

```yaml
strandedness:
  infer_experiment: true       # infer_experiment.txt
  multiqc_strandedness: true   # MultiQC general stats
```

## What This Replaces

| Tool | Language | Speed | RustQC |
|------|----------|-------|--------|
| RSeQC `infer_experiment.py` | Python | Separate BAM pass + BED12 | Same pass, zero cost |

## Checklist
- [x] `cargo test` — all tests pass (unit + integration)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] 11 unit tests in `strandedness.rs`
- [x] Documentation (module docs, public item docs)