### PR TITLE
Fix dupradar MultiQC curve file header

### DIFF
--- a/src/rna/dupradar/plots.rs
+++ b/src/rna/dupradar/plots.rs
@@ -1356,7 +1356,6 @@ pub fn write_mqc_curve(fit: &FitResult, dm: &DupMatrix, path: &std::path::Path) 
     let lmax = mx.log10();
     let n = 100;
 
-    writeln!(f, "RPK\tDuplication Rate (%)")?;
     for i in 0..=n {
         let lr = lmin + (lmax - lmin) * (i as f64) / (n as f64);
         let rpk = 10.0_f64.powf(lr);


### PR DESCRIPTION
## Summary

Remove the uncommented TSV header row (`RPK\tDuplication Rate (%)`) from `duprateExpDensCurve_mqc.txt`, matching the nf-core dupRadar R script format (`col.names=FALSE`).

## Problem

MultiQC's `custom_content` linegraph parser does not support uncommented column headers in `.txt` data files. The header row is parsed as data alongside the numeric rows, creating a dict with mixed string and float keys. This crashes `sorted(xs)` in the linegraph plotter, which takes down the entire `custom_content` module (dupradar, biotype counts, strandedness checks, etc.).

### Relevant MultiQC code

- [`_find_file_header()`](https://github.com/MultiQC/MultiQC/blob/b762196a99bb2f49132a1ca57186581aad30c923/multiqc/core/special_case_modules/custom_content.py#L625-L670): For `.txt` files, `sep` stays `None` (line 637-640), so the column-name detection at lines 643-650 never triggers. The uncommented header row goes into `other_lines` as data.
- [`_parse_txt()` line 936-939](https://github.com/MultiQC/MultiQC/blob/b762196a99bb2f49132a1ca57186581aad30c923/multiqc/core/special_case_modules/custom_content.py#L936-L939): All rows (including the header) are iterated into `data_dict`, mixing `str` and `float` keys.
- [`linegraph.py` line 779](https://github.com/MultiQC/MultiQC/blob/b762196a99bb2f49132a1ca57186581aad30c923/multiqc/plots/linegraph.py#L779): `sorted(xs)` fails with `TypeError: '<' not supported between instances of 'float' and 'str'`.

Commenting the header doesn't help either - YAML doesn't allow literal tab characters, so `# RPK\t...` breaks YAML parsing.

## Fix

One-line deletion of `writeln!(f, "RPK\tDuplication Rate (%)")?;` in `plots.rs`. The YAML comment block already defines the axis labels.

Found during nf-core/rnaseq integration testing: https://github.com/seqeralabs/rnaseq/pull/1#issuecomment-4154029781