### PR TITLE
fix: use clean sample name in biotype_counts_rrna_mqc.tsv

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1164,7 +1164,7 @@ fn process_single_bam(
                     &mqc_rrna_path,
                     &biotype_counts,
                     count_result.fc_biotype_assigned,
-                    bam_stem,
+                    &sample_name,
                 )?;
                 let p = mqc_rrna_path.display().to_string();
                 ui.output_detail(&format!("rRNA MultiQC: {p}"));


### PR DESCRIPTION
## Summary
- Fixes phantom rows in MultiQC's General Stats table caused by `.markdup.sorted` (and similar suffixes) appearing in the Sample column of `biotype_counts_rrna_mqc.tsv`
- The `write_biotype_rrna_mqc` call was passing `bam_stem` instead of the already-cleaned `sample_name`
- One-line fix: `bam_stem` → `&sample_name` in the call site

Fixes #46

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` - all 229 tests pass
- [x] Manual test with `RAP1_UNINDUCED_REP1.markdup.sorted.bam` confirms Sample column now shows `RAP1_UNINDUCED_REP1`
- [x] `biotype_counts_mqc.tsv` (filename-based naming) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)