### PR TITLE
fix: include overflow bucket in IS histogram output

### DIFF
--- a/src/rna/rseqc/stats.rs
+++ b/src/rna/rseqc/stats.rs
@@ -677,20 +677,14 @@ fn write_insert_size<W: std::io::Write>(
     // We compute on the raw (double-counted) histogram using f64 to match
     // samtools' 0.5 multiplication (which preserves fractional halves).
     const MAX_INSERT_SIZE: u64 = 8000;
-    let max_key = is_hist
-        .keys()
-        .filter(|&&k| k < MAX_INSERT_SIZE)
-        .max()
-        .copied()
-        .unwrap_or(0);
 
     // Halved total (nisize), matching samtools: sum of (count * 0.5)
     // across ALL buckets including the overflow cap.
     let nisize: f64 = is_hist.values().map(|v| v[0] as f64 * 0.5).sum();
 
     let mut bulk: f64 = 0.0;
-    let mut bulk_limit: u64 = max_key;
-    for isize_val in 0..=max_key {
+    let mut bulk_limit: u64 = 0;
+    for isize_val in 0..=MAX_INSERT_SIZE {
         let count = is_hist.get(&isize_val).map(|v| v[0]).unwrap_or(0);
         if count > 0 {
             bulk_limit = isize_val + 1;


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #60 where the IS histogram bulk cutoff loop excluded the overflow bucket (key 8000).

PR #60 rewrote the IS histogram output to add 99% bulk truncation matching samtools stats.c. It correctly included the overflow bucket in `nisize` (the denominator), but the loop that accumulates toward the 99% threshold was bounded by `max_key` - filtered to keys `< MAX_INSERT_SIZE` (8000). When a significant number of pairs land in the overflow bucket (1,924 in the benchmark test data), `bulk/nisize` can't reach 0.99 within the loop range, and the final rows are silently dropped.

The fix replaces `0..=max_key` with `0..=MAX_INSERT_SIZE`, allowing the loop to reach the overflow bucket when needed. This matches samtools stats.c, which iterates its full 0..8000 array.

Closes #65

## Verification

Built a local Docker image with the fix and ran the RustQC-benchmarks pipeline as described in the issue:

```bash
# Build fixed image
docker build -t rustqc:fix-is-65 .

# Run RustQC via benchmarks pipeline
nextflow run . -profile rna_test,docker \
    --rustqc_image rustqc:fix-is-65 \
    --run_upstream false --outdir /tmp/bench-rustqc-fixed

# Run upstream samtools via benchmarks pipeline
nextflow run . -profile rna_test,docker \
    --run_rustqc false --run_upstream true --outdir /tmp/bench-upstream

# Compare
diff <(grep -v '^#' /tmp/bench-rustqc-fixed/rustqc/samtools/test.stats) \
     <(grep -v '^#' /tmp/bench-upstream/samtools/test.stats)
```

Results:
- IS histogram tails now match (rows through IS 8000 present, catchall bin shows 1,924 pairs)
- Non-comment line counts match (10,562 each)
- Full diff is empty - zero differences

## Test plan

- [x] `cargo check` passes
- [x] All 220 tests pass (208 unit + 12 integration)
- [x] End-to-end verification via RustQC-benchmarks `rna_test` profile with Docker, diffing against upstream `samtools stats` (zero diff, matching the reproduction steps in #65)

🤖 Generated with [Claude Code](https://claude.com/claude-code)