### PR TITLE
Fix broken links on RNA benchmark details page

### DIFF
--- a/docs/src/content/docs/rna/benchmark-details.mdx
+++ b/docs/src/content/docs/rna/benchmark-details.mdx
@@ -44,8 +44,8 @@ across chromosomes.
 ## Output correctness
 
 Per-tool comparison tables and known differences are on the individual tool pages:
-[dupRadar](../rna/dupradar/), [featureCounts](../rna/featurecounts/), [RSeQC](../rna/rseqc/),
-[preseq](../rna/preseq/), [Samtools](../rna/samtools/), [Qualimap](../rna/qualimap/).
+[dupRadar](../dupradar/), [featureCounts](../featurecounts/), [RSeQC](../rseqc/),
+[preseq](../preseq/), [Samtools](../samtools/), [Qualimap](../qualimap/).
 
 ## Upstream tool versions
 

--- a/docs/src/content/docs/rna/dupradar.mdx
+++ b/docs/src/content/docs/rna/dupradar.mdx
@@ -271,7 +271,7 @@ RustQC produces output matching R dupRadar to floating-point precision. All 14 o
 
 </details>
 
-> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../rna/benchmark-details/) for a full breakdown.
+> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../benchmark-details/) for a full breakdown.
 
 ### Results comparison
 

--- a/docs/src/content/docs/rna/featurecounts.mdx
+++ b/docs/src/content/docs/rna/featurecounts.mdx
@@ -137,7 +137,7 @@ compatible with the Subread featureCounts format. Benchmarks were run on AWS clo
 
 </details>
 
-> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../rna/benchmark-details/) for a full breakdown.
+> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../benchmark-details/) for a full breakdown.
 
 The 1s CPU time for featureCounts reflects that the small dataset is trivially sized and most wall time is container startup.
 

--- a/docs/src/content/docs/rna/preseq.mdx
+++ b/docs/src/content/docs/rna/preseq.mdx
@@ -116,7 +116,7 @@ run on AWS cloud infrastructure on 2026-03-09.
 
 ### Performance
 
-> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../rna/benchmark-details/) for a full breakdown.
+> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../benchmark-details/) for a full breakdown.
 
 The extrapolation computation itself is fast (under 1 second) -- it is purely a function of the histogram data.
 

--- a/docs/src/content/docs/rna/qualimap.mdx
+++ b/docs/src/content/docs/rna/qualimap.mdx
@@ -333,7 +333,7 @@ eliminating the separate name-sort and Qualimap run required by the original Jav
 
 </details>
 
-> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../rna/benchmark-details/) for a full breakdown.
+> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../benchmark-details/) for a full breakdown.
 
 On the small dataset, RustQC uses 182 MB of memory vs Qualimap's 705 MB.
 

--- a/docs/src/content/docs/rna/samtools.mdx
+++ b/docs/src/content/docs/rna/samtools.mdx
@@ -183,7 +183,7 @@ validated on two datasets from an AWS cloud run (nf-core AWS megatests, 2026-03-
 
 ### Performance
 
-> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../rna/benchmark-details/) for a full breakdown.
+> **Note:** RustQC runtime shown is for all tools combined in a single pass. See [Benchmark Details](../benchmark-details/) for a full breakdown.
 
 Individual Samtools tool times are shown for reference.
 


### PR DESCRIPTION
## Summary
- Fix relative links within `docs/src/content/docs/rna/` that used `../rna/<page>/` instead of `../<page>/`, causing the `rna/` path segment to be doubled (e.g. `/RustQC/rna/rna/dupradar/`)
- Affects 6 files: benchmark-details, dupradar, featurecounts, preseq, qualimap, samtools

## Test plan
- [ ] Verify links on https://seqeralabs.github.io/RustQC/rna/benchmark-details/ resolve correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)