### PR TITLE
fix: use .log extension for junction_annotation output

### DIFF
--- a/docs/src/content/docs/rna/rseqc.mdx
+++ b/docs/src/content/docs/rna/rseqc.mdx
@@ -290,7 +290,7 @@ Splice junction classification against a reference gene model.
 | `{stem}.splice_events.svg`       | Splice events pie chart (SVG)                                                                                     |
 | `{stem}.splice_junction.png`     | Splice junctions pie chart (PNG)                                                                                  |
 | `{stem}.splice_junction.svg`     | Splice junctions pie chart (SVG)                                                                                  |
-| `{stem}.junction_annotation.txt` | Summary: total/known/partial novel/complete novel event and junction counts                                       |
+| `{stem}.junction_annotation.log` | Summary: total/known/partial novel/complete novel event and junction counts                                       |
 
 Junctions are classified by comparing splice sites (CIGAR N-operations)
 against the reference gene model:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1676,7 +1676,7 @@ fn write_rseqc_outputs(
         rna::rseqc::plots::junction_annotation_plot(&results, &prefix, sample_name)?;
 
         let summary_path =
-            rseqc_junc_annot_dir.join(format!("{}.junction_annotation.txt", sample_name));
+            rseqc_junc_annot_dir.join(format!("{}.junction_annotation.log", sample_name));
         rna::rseqc::junction_annotation::write_summary(&results, &summary_path, params.gtf_path)?;
 
         // Only print the detailed junction summary in verbose mode

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -313,7 +313,7 @@ fn test_all_output_files_generated() {
         "rseqc/read_duplication/test.pos.DupRate.xls",
         "rseqc/read_duplication/test.seq.DupRate.xls",
         "rseqc/read_distribution/test.read_distribution.txt",
-        "rseqc/junction_annotation/test.junction_annotation.txt",
+        "rseqc/junction_annotation/test.junction_annotation.log",
         "rseqc/junction_saturation/test.junctionSaturation_summary.txt",
         "rseqc/inner_distance/test.inner_distance.txt",
     ];
@@ -700,7 +700,7 @@ fn test_flat_output_no_subdirectories() {
         "test.pos.DupRate.xls",
         "test.seq.DupRate.xls",
         "test.read_distribution.txt",
-        "test.junction_annotation.txt",
+        "test.junction_annotation.log",
         "test.junctionSaturation_summary.txt",
         "test.inner_distance.txt",
     ];


### PR DESCRIPTION
## Summary

- Change junction_annotation summary output from `.txt` to `.log` extension to match RSeQC's `junction_annotation.py`

## Context

MultiQC's default search pattern for `rseqc/junction_annotation` looks for `*.junction_annotation.log`. RustQC was outputting `.txt`, requiring pipeline-level workarounds in the MultiQC config.

Fixes #79
Context: nf-core/rnaseq#1754

## Changes

- `src/main.rs`: `.junction_annotation.txt` -> `.junction_annotation.log`
- `tests/integration_test.rs`: update expected filenames
- `docs/src/content/docs/rna/rseqc.mdx`: update output table