### PR TITLE
feat: add geneBody_coverage and read_GC RSeQC tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,9 @@ src/
       junction_saturation.rs — junction_saturation.py reimplementation
       plots.rs              — RSeQC plot generation (duplication, junctions, etc.)
       read_distribution.rs  — read_distribution.py reimplementation
+      gene_body_coverage.rs — geneBody_coverage.py reimplementation (5'->3' profile)
       read_duplication.rs   — read_duplication.py reimplementation
+      read_gc.rs            — read_GC.py reimplementation (GC distribution)
       stats.rs              — samtools stats full output (SN + all histogram sections)
       tin.rs                — TIN (Transcript Integrity Number) analysis
 tests/
@@ -294,6 +296,12 @@ forwarded to `count_reads()` as the `skip_dup_check: bool` parameter).
   `infer_experiment:`, `read_duplication:`, `read_distribution:`, `junction_annotation:`,
   `junction_saturation:`, `inner_distance:`, `tin:`). Each has an `enabled: bool` toggle
   and tool-specific parameter overrides. CLI flags take precedence over config values.
+- `gene_body_coverage` samples 100 percentile positions per representative transcript
+  using a direct port of RSeQC's `mystat.percentile_list`, including Python's
+  round-half-to-even. Do not replace that with `f64::round` — it shifts sampled
+  positions by a base and changes bin counts.
+- `read_gc` follows upstream `readGC` filters: skip unmapped/QC-fail/below-MAPQ,
+  but keep secondary alignments and duplicates.
 - Under `rna:`, there are also sections for `preseq:`, `qualimap:`,
   `flagstat:`, `idxstats:`, and `samtools_stats:`. Each has an `enabled: bool` toggle.
   Preseq has additional parameters: `max_extrap`, `step_size`, `n_bootstraps`,

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -162,7 +162,8 @@ export const base = import.meta.env.BASE_URL;
 <CardGrid stagger>
   <Card title="Matching Results" icon="approve-check">
     Produces identical or near-identical output to R's dupRadar and featureCounts,
-    plus faithful reimplementations of 8 RSeQC tools (including TIN), preseq,
+    plus faithful reimplementations of 10 RSeQC tools (including TIN, geneBody_coverage
+    and read_GC), preseq,
     and samtools. See [benchmark details](./rna/benchmark-details/).
   </Card>
   <Card title="Dramatically Faster" icon="rocket">

--- a/docs/src/content/docs/rna/rseqc.mdx
+++ b/docs/src/content/docs/rna/rseqc.mdx
@@ -13,8 +13,8 @@ RSeQC is a Python package providing a suite of quality control tools for RNA-Seq
 [Documentation](https://rseqc.sourceforge.net/) | [Source code](https://github.com/MonashBioinformaticsPlatform/RSeQC)
 </Aside>
 
-RustQC reimplements eight tools from the [RSeQC](https://rseqc.sourceforge.net/)
-package (including TIN). Each tool produces output files that match the format
+RustQC reimplements ten tools from the [RSeQC](https://rseqc.sourceforge.net/)
+package (including TIN, geneBody_coverage and read_GC). Each tool produces output files that match the format
 and content of the original Python implementation, plus **native PNG and SVG
 plots** generated directly -- no R scripts required.
 
@@ -608,6 +608,77 @@ show larger differences due to the coverage counting approach described above.
 RustQC produces gene-level TIN scores (one row per gene, using the longest
 transcript as representative), while RSeQC's `tin.py` produces transcript-level
 scores. Both formats are compatible with MultiQC.
+
+## geneBody_coverage
+
+Read coverage along the gene body, 5' → 3', in 100 percentile bins — the
+standard signal for RNA degradation and 3'-end bias.
+
+| File                                    | Description                                        |
+| --------------------------------------- | -------------------------------------------------- |
+| `{stem}.geneBodyCoverage.txt`           | Percentile header row + one row of coverage per sample |
+| `{stem}.geneBodyCoverage.r`             | R plotting script (as RSeQC writes)                |
+| `{stem}.geneBodyCoverage.curves.png/svg` | Coverage curve, rendered natively                  |
+
+```
+Percentile	1	2	3	...	100
+sample	4.0	10.0	15.0	...	1.0
+```
+
+Each transcript's exonic bases are reduced to 100 percentile positions using
+the same interpolation as RSeQC's `mystat.percentile_list`, coverage is counted
+at those positions, and reverse-strand transcripts are flipped so bin 1 is
+always the 5' end. Transcripts shorter than 100 bp are skipped, matching
+RSeQC's `--minimum_length` default. Reads are filtered on unmapped, QC-fail,
+secondary and duplicate flags.
+
+<Aside type="note" title="Reference transcripts">
+RSeQC profiles every entry of a BED12 reference — usually a housekeeping-gene
+set. RustQC has no separate BED input here and instead profiles one
+representative transcript per gene from the GTF (the one with the most exonic
+bases), the same choice its TIN analysis makes. Coverage values therefore match
+RSeQC exactly for a given transcript set, but the transcript set itself depends
+on the annotation you pass.
+</Aside>
+
+<Aside type="tip" title="Not the same as Qualimap gene body coverage">
+RustQC also produces Qualimap-style gene body coverage. Qualimap bins each
+transcript into fixed relative windows; RSeQC samples percentile *positions* and
+pools raw depth across transcripts. The two profiles are related but not
+interchangeable.
+</Aside>
+
+Disable with `--skip-gene-body-coverage` or `rna.gene_body_coverage.enabled: false`.
+
+## read_GC
+
+GC-content distribution of mapped reads — the standard check for GC bias from
+library preparation or sequencing.
+
+| File                    | Description                                     |
+| ----------------------- | ----------------------------------------------- |
+| `{stem}.GC.xls`         | `GC%` / `read_count` table                      |
+| `{stem}.GC_plot.r`      | R plotting script (as RSeQC writes)             |
+| `{stem}.GC_plot.png/svg` | GC distribution, rendered natively             |
+
+```
+GC%	read_count
+0.00	483
+```
+
+Filters match RSeQC's `readGC`: unmapped, QC-failed and below-MAPQ-cutoff reads
+are skipped, while secondary alignments and duplicates are counted (upstream
+does not filter them). GC percentages are formatted with two decimals, as
+upstream does.
+
+Rows are sorted ascending by GC percentage. RSeQC emits Python dictionary order,
+which depends on the order reads appear in the BAM and is therefore not
+reproducible under parallel processing.
+
+Reads stored without a sequence (`SEQ` = `*`) are skipped and reported as a
+warning; upstream divides by zero on those.
+
+Disable with `--skip-read-gc` or `rna.read_gc.enabled: false`.
 
 ## Compatibility with RSeQC
 

--- a/docs/src/content/docs/usage/configuration.md
+++ b/docs/src/content/docs/usage/configuration.md
@@ -153,6 +153,8 @@ Run `rustqc rna --help` to see the associated environment variable for each flag
 | `RUSTQC_TIN_SEED` | `--tin-seed` |
 | `RUSTQC_SKIP_TIN` | `--skip-tin` |
 | `RUSTQC_SKIP_READ_DUPLICATION` | `--skip-read-duplication` |
+| `RUSTQC_SKIP_GENE_BODY_COVERAGE` | `--skip-gene-body-coverage` |
+| `RUSTQC_SKIP_READ_GC` | `--skip-read-gc` |
 | `RUSTQC_SKIP_PRESEQ` | `--skip-preseq` |
 | `RUSTQC_PRESEQ_SEED` | `--preseq-seed` |
 | `RUSTQC_PRESEQ_MAX_EXTRAP` | `--preseq-max-extrap` |
@@ -522,6 +524,32 @@ measures transcript integrity via Shannon entropy of read coverage uniformity.
 The `seed` can also be set via `--tin-seed`.
 
 > **CLI shortcut:** Use `--skip-tin` to disable without a config file.
+
+## gene_body_coverage
+
+```yaml
+rna:
+  gene_body_coverage:
+    enabled: true # Set to false to skip gene body coverage profiling
+```
+
+Requires annotation (`--gtf`). Profiles read coverage along the gene body from
+5' to 3' in 100 percentile bins, matching RSeQC's `geneBody_coverage.py`.
+
+> **CLI shortcut:** Use `--skip-gene-body-coverage` to disable without a config file.
+
+## read_gc
+
+```yaml
+rna:
+  read_gc:
+    enabled: true # Set to false to skip the read GC distribution
+```
+
+GC-content distribution of mapped reads, matching RSeQC's `read_GC.py`. Uses the
+`--mapq` cutoff.
+
+> **CLI shortcut:** Use `--skip-read-gc` to disable without a config file.
 
 ## qualimap
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -305,6 +305,24 @@ pub struct RnaArgs {
     )]
     pub skip_tin: bool,
 
+    /// Skip gene body coverage profiling
+    #[arg(
+        long,
+        default_value_t = false,
+        env = "RUSTQC_SKIP_GENE_BODY_COVERAGE",
+        help_heading = "Tool parameters"
+    )]
+    pub skip_gene_body_coverage: bool,
+
+    /// Skip read GC distribution
+    #[arg(
+        long,
+        default_value_t = false,
+        env = "RUSTQC_SKIP_READ_GC",
+        help_heading = "Tool parameters"
+    )]
+    pub skip_read_gc: bool,
+
     /// Skip read duplication analysis
     #[arg(
         long,

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,14 @@ pub struct RnaConfig {
     /// Qualimap RNA-Seq QC configuration.
     #[serde(default)]
     pub qualimap: QualimapConfig,
+
+    /// Gene body coverage (RSeQC geneBody_coverage) configuration.
+    #[serde(default)]
+    pub gene_body_coverage: GeneBodyCoverageConfig,
+
+    /// Read GC distribution (RSeQC read_GC) configuration.
+    #[serde(default)]
+    pub read_gc: ReadGcConfig,
 }
 
 // ============================================================================
@@ -595,6 +603,49 @@ pub struct QualimapConfig {
 }
 
 impl Default for QualimapConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+/// Configuration for gene body coverage profiling (RSeQC `geneBody_coverage.py`).
+///
+/// Profiles read coverage along the gene body from 5' to 3' in 100 percentile
+/// bins — the standard signal for RNA degradation and 3'-end bias.
+///
+/// Example:
+/// ```yaml
+/// gene_body_coverage:
+///   enabled: true
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct GeneBodyCoverageConfig {
+    /// Whether to profile gene body coverage. Defaults to true.
+    pub enabled: bool,
+}
+
+impl Default for GeneBodyCoverageConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+/// Configuration for the read GC distribution (RSeQC `read_GC.py`).
+///
+/// Example:
+/// ```yaml
+/// read_gc:
+///   enabled: true
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct ReadGcConfig {
+    /// Whether to compute the read GC distribution. Defaults to true.
+    pub enabled: bool,
+}
+
+impl Default for ReadGcConfig {
     fn default() -> Self {
         Self { enabled: true }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! RustQC — fast quality control tools for sequencing data.
 //!
 //! RustQC is primarily a CLI (`rustqc rna ...`) that runs a single-pass
-//! RNA-Seq QC pipeline (dupRadar, featureCounts, 8 RSeQC tools, Qualimap,
+//! RNA-Seq QC pipeline (dupRadar, featureCounts, 10 RSeQC tools, Qualimap,
 //! preseq, samtools-style outputs). The same analysis modules are also
 //! exposed as a library so they can be embedded into other Rust programs.
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,12 @@ fn run_rna(args: cli::RnaArgs, ui: &Ui) -> Result<()> {
     if args.skip_read_duplication {
         config.read_duplication.enabled = false;
     }
+    if args.skip_gene_body_coverage {
+        config.gene_body_coverage.enabled = false;
+    }
+    if args.skip_read_gc {
+        config.read_gc.enabled = false;
+    }
     if args.skip_preseq {
         config.preseq.enabled = false;
     }
@@ -471,6 +477,15 @@ fn run_rna(args: cli::RnaArgs, ui: &Ui) -> Result<()> {
         None
     };
 
+    let gene_body_index = if config.gene_body_coverage.enabled {
+        ui.detail("Building gene body coverage index...");
+        Some(rna::rseqc::gene_body_coverage::GeneBodyIndex::from_genes(
+            &genes,
+        ))
+    } else {
+        None
+    };
+
     let chrom_mapping = config.alignment_to_gtf_mapping();
     let chrom_prefix = config.chromosome_prefix().map(|s| s.to_owned());
 
@@ -570,6 +585,7 @@ fn run_rna(args: cli::RnaArgs, ui: &Ui) -> Result<()> {
         tin_min_coverage: config.tin.min_coverage.unwrap_or(10),
         gtf_path: &args.gtf,
         sample_name_override: effective_sample_name,
+        gene_body_index: gene_body_index.as_ref(),
     };
 
     // Step 2: Process all alignment files (in parallel when multiple)
@@ -815,6 +831,8 @@ struct SharedParams<'a> {
     tin_min_coverage: u32,
     /// Path to GTF file (for Qualimap report output).
     gtf_path: &'a str,
+    /// Pre-built sampled positions for gene body coverage (from GTF).
+    gene_body_index: Option<&'a rna::rseqc::gene_body_coverage::GeneBodyIndex>,
 }
 
 // ============================================================================
@@ -988,6 +1006,9 @@ fn process_single_bam(
         junction_saturation_seed: config.junction_saturation.seed.unwrap_or(42),
         preseq_enabled: config.preseq.enabled,
         preseq_max_segment_length: config.preseq.max_segment_length,
+        gene_body_coverage_enabled: config.gene_body_coverage.enabled
+            && params.gene_body_index.is_some_and(|i| !i.is_empty()),
+        read_gc_enabled: config.read_gc.enabled,
     };
 
     let rseqc_annotations = RseqcAnnotations {
@@ -997,6 +1018,7 @@ fn process_single_bam(
         exon_bitset: params.exon_bitset,
         transcript_tree: params.transcript_tree,
         tin_index: params.tin_index,
+        gene_body_index: params.gene_body_index,
     };
 
     let any_rseqc_enabled = rseqc_config.bam_stat_enabled
@@ -1007,7 +1029,9 @@ fn process_single_bam(
         || rseqc_config.junction_saturation_enabled
         || rseqc_config.inner_distance_enabled
         || rseqc_config.preseq_enabled
-        || rseqc_config.tin_enabled;
+        || rseqc_config.tin_enabled
+        || rseqc_config.gene_body_coverage_enabled
+        || rseqc_config.read_gc_enabled;
 
     // === Build Qualimap exon index (if enabled) ===
     let qualimap_index = if params.config.qualimap.enabled {
@@ -1869,6 +1893,75 @@ fn write_rseqc_outputs(
                 ui.warn(&format!("preseq: skipped — {}", e));
             }
         }
+    }
+
+    // --- gene body coverage (5' -> 3') ---
+    if let (Some(accum), Some(index)) = (accums.gene_body, params.gene_body_index) {
+        let gbc_dir = if flat {
+            outdir.to_path_buf()
+        } else {
+            outdir.join("rseqc").join("gene_body_coverage")
+        };
+        std::fs::create_dir_all(&gbc_dir)?;
+        let result = accum.into_result(index);
+
+        let txt_path = gbc_dir.join(format!("{}.geneBodyCoverage.txt", sample_name));
+        rna::rseqc::gene_body_coverage::write_gene_body_coverage(&result, sample_name, &txt_path)?;
+
+        let prefix = gbc_dir.join(sample_name).display().to_string();
+        let r_path = gbc_dir.join(format!("{}.geneBodyCoverage.r", sample_name));
+        rna::rseqc::gene_body_coverage::write_gene_body_r_script(
+            &result,
+            sample_name,
+            &prefix,
+            &r_path,
+        )?;
+
+        let plot_path = gbc_dir.join(format!("{}.geneBodyCoverage.curves.png", sample_name));
+        rna::rseqc::plots::gene_body_coverage_plot(&result, sample_name, &plot_path)?;
+
+        let p = gbc_dir.display().to_string();
+        ui.output_item("gene_body_coverage", &format!("{p}/{sample_name}.*"));
+        ui.output_detail(&format!(
+            "{} transcripts profiled",
+            format_count(result.num_transcripts as u64)
+        ));
+        written.push(("gene_body_coverage".into(), p));
+    }
+
+    // --- read GC distribution ---
+    if let Some(accum) = accums.read_gc {
+        let gc_dir = if flat {
+            outdir.to_path_buf()
+        } else {
+            outdir.join("rseqc").join("read_gc")
+        };
+        std::fs::create_dir_all(&gc_dir)?;
+        let result = accum.into_result();
+
+        let xls_path = gc_dir.join(format!("{}.GC.xls", sample_name));
+        rna::rseqc::read_gc::write_gc_table(&result, &xls_path)?;
+
+        let prefix = gc_dir.join(sample_name).display().to_string();
+        let r_path = gc_dir.join(format!("{}.GC_plot.r", sample_name));
+        rna::rseqc::read_gc::write_gc_r_script(&result, &prefix, &r_path)?;
+
+        let plot_path = gc_dir.join(format!("{}.GC_plot.png", sample_name));
+        rna::rseqc::plots::read_gc_plot(&result, sample_name, &plot_path)?;
+
+        if result.missing_sequence > 0 {
+            ui.warn(&format!(
+                "read_GC: {} reads had no stored sequence and were skipped",
+                format_count(result.missing_sequence)
+            ));
+        }
+
+        let p = gc_dir.display().to_string();
+        ui.output_item("read_GC", &format!("{p}/{sample_name}.*"));
+        if let Some(mean) = result.mean_gc() {
+            ui.output_detail(&format!("mean GC {:.2}%", mean));
+        }
+        written.push(("read_GC".into(), p));
     }
 
     Ok(RseqcOutputs {

--- a/src/rna/rseqc/accumulators.rs
+++ b/src/rna/rseqc/accumulators.rs
@@ -50,6 +50,8 @@ pub struct RseqcAnnotations<'a> {
 
     /// TIN index for transcript integrity number calculation.
     pub tin_index: Option<&'a super::tin::TinIndex>,
+    /// Sampled percentile positions for gene body coverage.
+    pub gene_body_index: Option<&'a super::gene_body_coverage::GeneBodyIndex>,
 }
 
 /// Per-tool configuration parameters.
@@ -97,6 +99,10 @@ pub struct RseqcConfig {
     pub inner_distance_enabled: bool,
     /// Whether TIN analysis is enabled.
     pub tin_enabled: bool,
+    /// Whether gene body coverage profiling is enabled.
+    pub gene_body_coverage_enabled: bool,
+    /// Whether the read GC distribution is enabled.
+    pub read_gc_enabled: bool,
     /// Number of equally-spaced sampling positions per transcript for TIN.
     pub tin_sample_size: usize,
     /// Minimum number of read starts for a transcript to compute TIN.
@@ -2123,6 +2129,10 @@ pub struct RseqcAccumulators {
     pub tin: Option<TinAccum>,
     /// preseq library complexity accumulator (`None` when disabled).
     pub preseq: Option<PreseqAccum>,
+    /// gene body coverage accumulator (`None` when disabled).
+    pub gene_body: Option<super::gene_body_coverage::GeneBodyCoverageAccum>,
+    /// read GC distribution accumulator (`None` when disabled).
+    pub read_gc: Option<super::read_gc::ReadGcAccum>,
 }
 
 impl RseqcAccumulators {
@@ -2138,6 +2148,8 @@ impl RseqcAccumulators {
             inner_dist: None,
             tin: None,
             preseq: None,
+            gene_body: None,
+            read_gc: None,
         }
     }
 
@@ -2193,6 +2205,18 @@ impl RseqcAccumulators {
             },
             preseq: if config.preseq_enabled {
                 Some(PreseqAccum::new(config.preseq_max_segment_length))
+            } else {
+                None
+            },
+            gene_body: if config.gene_body_coverage_enabled {
+                annotations
+                    .and_then(|a| a.gene_body_index)
+                    .map(super::gene_body_coverage::GeneBodyCoverageAccum::new)
+            } else {
+                None
+            },
+            read_gc: if config.read_gc_enabled {
+                Some(super::read_gc::ReadGcAccum::new(config.mapq_cut))
             } else {
                 None
             },
@@ -2283,6 +2307,18 @@ impl RseqcAccumulators {
         if let Some(ref mut accum) = self.preseq {
             accum.process_read(record);
         }
+
+        // gene body coverage: needs sampled positions, uses uppercased chrom
+        if let (Some(ref mut accum), Some(index)) =
+            (&mut self.gene_body, annotations.gene_body_index)
+        {
+            accum.process_read(record, chrom_upper, index);
+        }
+
+        // read GC: sequence-only, applies its own MAPQ/flag filters
+        if let Some(ref mut accum) = self.read_gc {
+            accum.process_read(record);
+        }
     }
 
     /// Merge another set of accumulators into this one.
@@ -2312,6 +2348,12 @@ impl RseqcAccumulators {
             a.merge(b);
         }
         if let (Some(ref mut a), Some(b)) = (&mut self.preseq, other.preseq) {
+            a.merge(b);
+        }
+        if let (Some(ref mut a), Some(b)) = (&mut self.gene_body, other.gene_body) {
+            a.merge(b);
+        }
+        if let (Some(ref mut a), Some(b)) = (&mut self.read_gc, other.read_gc) {
             a.merge(b);
         }
     }

--- a/src/rna/rseqc/gene_body_coverage.rs
+++ b/src/rna/rseqc/gene_body_coverage.rs
@@ -1,0 +1,603 @@
+//! Gene body coverage profiling (5' → 3').
+//!
+//! Reimplementation of RSeQC's `geneBody_coverage.py`. Each transcript's
+//! exonic bases are reduced to 100 percentile positions; read coverage at
+//! those positions is accumulated across transcripts into a 100-bin profile
+//! running 5' → 3'. Non-uniform profiles are the standard signal for RNA
+//! degradation and 3'-end bias.
+//!
+//! Note that this is a different measurement from the Qualimap gene body
+//! coverage RustQC also produces: Qualimap bins each transcript into fixed
+//! relative windows, while RSeQC samples percentile *positions* and pools the
+//! raw depth across transcripts.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use indexmap::IndexMap;
+use log::debug;
+use rust_htslib::bam;
+
+use crate::gtf::Gene;
+use crate::rna::bam_flags::{BAM_FDUP, BAM_FQCFAIL, BAM_FSECONDARY, BAM_FUNMAP};
+
+/// Number of percentile bins along the gene body.
+pub const NUM_BINS: usize = 100;
+
+/// Minimum mRNA length for a transcript to be profiled.
+///
+/// Matches RSeQC's `--minimum_length` default; shorter transcripts are skipped.
+pub const MIN_MRNA_LENGTH: usize = 100;
+
+// ===================================================================
+// Index construction
+// ===================================================================
+
+/// Sampling metadata for one profiled transcript.
+#[derive(Debug, Clone)]
+struct GbcTranscript {
+    /// Whether the transcript is on the reverse strand (profile is flipped).
+    is_reverse: bool,
+    /// Offset of this transcript's first coverage slot.
+    slot_offset: usize,
+    /// Number of coverage slots (unique percentile positions, ≤ [`NUM_BINS`]).
+    num_slots: usize,
+}
+
+/// Percentile positions for all profiled transcripts, indexed for per-read lookup.
+#[derive(Debug, Default)]
+pub struct GeneBodyIndex {
+    /// Per-transcript metadata, in construction order.
+    transcripts: Vec<GbcTranscript>,
+    /// Uppercased chromosome → sorted `(position_1based, slot)` entries.
+    chrom_positions: HashMap<String, Vec<(u64, u32)>>,
+    /// Total number of coverage slots across all transcripts.
+    total_slots: usize,
+}
+
+impl GeneBodyIndex {
+    /// Number of transcripts contributing to the profile.
+    pub fn num_transcripts(&self) -> usize {
+        self.transcripts.len()
+    }
+
+    /// Whether any transcript was long enough to profile.
+    pub fn is_empty(&self) -> bool {
+        self.transcripts.is_empty()
+    }
+
+    /// Build the index from GTF gene annotations.
+    ///
+    /// One representative transcript per gene is profiled — the one with the
+    /// most exonic bases — matching how RustQC's TIN analysis picks a
+    /// representative. RSeQC instead profiles every entry of a BED12 reference
+    /// (typically a housekeeping-gene set).
+    pub fn from_genes(genes: &IndexMap<String, Gene>) -> Self {
+        let mut transcripts = Vec::new();
+        let mut chrom_positions: HashMap<String, Vec<(u64, u32)>> = HashMap::new();
+        let mut total_slots = 0usize;
+
+        for gene in genes.values() {
+            // Representative transcript: most exonic bases. Genes without
+            // transcript records fall back to their merged exon list.
+            let exons: Vec<(u64, u64)> = match gene
+                .transcripts
+                .iter()
+                .max_by_key(|t| t.exons.iter().map(|(s, e)| e - s + 1).sum::<u64>())
+            {
+                Some(tx) => tx.exons.clone(),
+                None => gene.exons.iter().map(|e| (e.start, e.end)).collect(),
+            };
+            if exons.is_empty() {
+                continue;
+            }
+
+            // 1-based inclusive exonic positions, ascending. GTF exon
+            // coordinates are already 1-based inclusive.
+            let mut sorted_exons = exons;
+            sorted_exons.sort_unstable();
+            let mrna_length: u64 = sorted_exons.iter().map(|(s, e)| e - s + 1).sum();
+            if (mrna_length as usize) < MIN_MRNA_LENGTH {
+                continue;
+            }
+
+            let mut bases: Vec<u64> = Vec::with_capacity(mrna_length as usize);
+            for &(start, end) in &sorted_exons {
+                bases.extend(start..=end);
+            }
+
+            let mut positions = percentile_positions(&bases);
+            positions.sort_unstable();
+            positions.dedup();
+            if positions.is_empty() {
+                continue;
+            }
+
+            let slot_offset = total_slots;
+            let num_slots = positions.len();
+            total_slots += num_slots;
+
+            let chrom_upper = gene.chrom.to_uppercase();
+            let entries = chrom_positions.entry(chrom_upper).or_default();
+            for (i, pos) in positions.into_iter().enumerate() {
+                entries.push((pos, (slot_offset + i) as u32));
+            }
+
+            transcripts.push(GbcTranscript {
+                is_reverse: gene.strand == '-',
+                slot_offset,
+                num_slots,
+            });
+        }
+
+        for entries in chrom_positions.values_mut() {
+            entries.sort_unstable();
+        }
+
+        debug!(
+            "Built gene body coverage index: {} transcripts, {} sampled positions",
+            transcripts.len(),
+            total_slots
+        );
+
+        GeneBodyIndex {
+            transcripts,
+            chrom_positions,
+            total_slots,
+        }
+    }
+}
+
+/// Compute the 100 percentile positions of a sorted position list.
+///
+/// Direct port of RSeQC's `mystat.percentile_list`: for `i` in 1..=100 it takes
+/// `k = (n - 1) * i / 100` and either the exact element (when `k` is integral)
+/// or the rounded linear interpolation between the neighbouring elements.
+/// Lists shorter than 100 entries are returned unchanged.
+fn percentile_positions(sorted: &[u64]) -> Vec<u64> {
+    if sorted.is_empty() {
+        return Vec::new();
+    }
+    if sorted.len() < NUM_BINS {
+        return sorted.to_vec();
+    }
+
+    let n = sorted.len();
+    let mut out = Vec::with_capacity(NUM_BINS);
+    for i in 1..=NUM_BINS {
+        let k = (n - 1) as f64 * i as f64 / 100.0;
+        let f = k.floor();
+        let c = k.ceil();
+        if (f - c).abs() < f64::EPSILON {
+            out.push(sorted[k as usize]);
+        } else {
+            let d0 = sorted[f as usize] as f64 * (c - k);
+            let d1 = sorted[c as usize] as f64 * (k - f);
+            out.push(round_half_to_even(d0 + d1) as u64);
+        }
+    }
+    out
+}
+
+/// Round half to even, matching Python's built-in `round()`.
+///
+/// `f64::round` rounds halves away from zero, which shifts interpolated
+/// percentile positions by one base relative to upstream whenever the
+/// interpolation lands exactly on `.5` — enough to change a bin's coverage by
+/// a read. Only non-negative values occur here.
+fn round_half_to_even(x: f64) -> f64 {
+    let floor = x.floor();
+    if x - floor == 0.5 {
+        if (floor as i64) % 2 == 0 {
+            floor
+        } else {
+            floor + 1.0
+        }
+    } else {
+        x.round()
+    }
+}
+
+// ===================================================================
+// Accumulator
+// ===================================================================
+
+/// Per-worker coverage counts at the sampled positions.
+#[derive(Debug, Clone)]
+pub struct GeneBodyCoverageAccum {
+    /// One counter per sampled position, indexed by slot.
+    counts: Vec<u32>,
+}
+
+impl GeneBodyCoverageAccum {
+    /// Create an accumulator sized for the given index.
+    pub fn new(index: &GeneBodyIndex) -> Self {
+        Self {
+            counts: vec![0; index.total_slots],
+        }
+    }
+
+    /// Add a single alignment record's coverage.
+    ///
+    /// Filters match the ones RSeQC applies inside its pileup loop: unmapped,
+    /// QC-failed, secondary and duplicate records are ignored, and positions
+    /// falling in a deletion or a skipped (`N`) region are not counted.
+    ///
+    /// # Arguments
+    /// * `record` - The alignment record
+    /// * `chrom_upper` - Uppercased chromosome name for this record
+    /// * `index` - The sampled-position index
+    pub fn process_read(&mut self, record: &bam::Record, chrom_upper: &str, index: &GeneBodyIndex) {
+        let flags = record.flags();
+        if flags & (BAM_FUNMAP | BAM_FQCFAIL | BAM_FSECONDARY | BAM_FDUP) != 0 {
+            return;
+        }
+
+        let Some(entries) = index.chrom_positions.get(chrom_upper) else {
+            return;
+        };
+
+        // Walk the CIGAR, counting only reference-consuming aligned blocks
+        // (M/=/X). Deletions and reference skips leave the read uncovered.
+        let mut ref_pos = record.pos() as u64; // 0-based
+        for op in record.cigar().iter() {
+            use rust_htslib::bam::record::Cigar;
+            match *op {
+                Cigar::Match(len) | Cigar::Equal(len) | Cigar::Diff(len) => {
+                    // Convert to 1-based inclusive [start, end]
+                    let start = ref_pos + 1;
+                    let end = ref_pos + len as u64;
+                    self.add_block(entries, start, end);
+                    ref_pos += len as u64;
+                }
+                Cigar::Del(len) | Cigar::RefSkip(len) => ref_pos += len as u64,
+                _ => {}
+            }
+        }
+    }
+
+    /// Increment every sampled position inside the 1-based inclusive block.
+    fn add_block(&mut self, entries: &[(u64, u32)], start: u64, end: u64) {
+        let lo = entries.partition_point(|&(pos, _)| pos < start);
+        for &(pos, slot) in &entries[lo..] {
+            if pos > end {
+                break;
+            }
+            self.counts[slot as usize] += 1;
+        }
+    }
+
+    /// Merge another worker's counts into this accumulator.
+    pub fn merge(&mut self, other: GeneBodyCoverageAccum) {
+        for (a, b) in self.counts.iter_mut().zip(other.counts.iter()) {
+            *a += b;
+        }
+    }
+
+    /// Aggregate per-position counts into the 5' → 3' profile.
+    ///
+    /// Reverse-strand transcripts have their coverage vector flipped before
+    /// aggregation, so bin 1 is always the 5' end.
+    pub fn into_result(self, index: &GeneBodyIndex) -> GeneBodyCoverageResult {
+        let mut coverage = vec![0u64; NUM_BINS];
+        let mut touched = vec![false; NUM_BINS];
+
+        for tx in &index.transcripts {
+            let slots = &self.counts[tx.slot_offset..tx.slot_offset + tx.num_slots];
+            for (i, &count) in slots.iter().enumerate() {
+                let bin = if tx.is_reverse {
+                    tx.num_slots - 1 - i
+                } else {
+                    i
+                };
+                coverage[bin] += count as u64;
+                touched[bin] = true;
+            }
+        }
+
+        GeneBodyCoverageResult {
+            coverage,
+            touched,
+            num_transcripts: index.num_transcripts(),
+        }
+    }
+}
+
+/// Aggregated 100-bin gene body coverage profile.
+#[derive(Debug, Clone)]
+pub struct GeneBodyCoverageResult {
+    /// Total coverage per percentile bin, 5' → 3'.
+    pub coverage: Vec<u64>,
+    /// Whether any transcript contributed to each bin.
+    touched: Vec<bool>,
+    /// Number of transcripts profiled.
+    pub num_transcripts: usize,
+}
+
+impl GeneBodyCoverageResult {
+    /// Coverage normalised to the range [0, 1] by the maximum bin.
+    ///
+    /// This is what RSeQC plots, and what makes profiles comparable between
+    /// samples of different depth.
+    pub fn normalised(&self) -> Vec<f64> {
+        let max = self.coverage.iter().copied().max().unwrap_or(0);
+        if max == 0 {
+            return vec![0.0; self.coverage.len()];
+        }
+        self.coverage
+            .iter()
+            .map(|&v| v as f64 / max as f64)
+            .collect()
+    }
+}
+
+// ===================================================================
+// Output
+// ===================================================================
+
+/// Write the `.geneBodyCoverage.txt` table.
+///
+/// Format matches RSeQC: a `Percentile` header row listing bins 1–100,
+/// followed by one row per sample.
+pub fn write_gene_body_coverage(
+    result: &GeneBodyCoverageResult,
+    sample_name: &str,
+    output_path: &Path,
+) -> Result<()> {
+    let mut out = std::fs::File::create(output_path).with_context(|| {
+        format!(
+            "Failed to create gene body coverage file: {}",
+            output_path.display()
+        )
+    })?;
+
+    let header: Vec<String> = (1..=NUM_BINS).map(|i| i.to_string()).collect();
+    writeln!(out, "Percentile\t{}", header.join("\t"))?;
+
+    let values: Vec<String> = result
+        .coverage
+        .iter()
+        .zip(result.touched.iter())
+        .map(|(&v, &touched)| {
+            if touched {
+                // Upstream accumulates Python floats here, so values print
+                // with a trailing ".0"
+                format!("{:.1}", v as f64)
+            } else {
+                "0".to_string()
+            }
+        })
+        .collect();
+    writeln!(out, "{}\t{}", sample_name, values.join("\t"))?;
+
+    debug!(
+        "Wrote gene body coverage to {} ({} transcripts)",
+        output_path.display(),
+        result.num_transcripts
+    );
+    Ok(())
+}
+
+/// Write the R plotting script RSeQC produces alongside the table.
+///
+/// RustQC renders the plot itself; the script is written for drop-in
+/// compatibility with pipelines that expect it.
+pub fn write_gene_body_r_script(
+    result: &GeneBodyCoverageResult,
+    sample_name: &str,
+    output_prefix: &str,
+    output_path: &Path,
+) -> Result<()> {
+    let mut out = std::fs::File::create(output_path).with_context(|| {
+        format!(
+            "Failed to create gene body coverage R script: {}",
+            output_path.display()
+        )
+    })?;
+
+    let normalised: Vec<String> = result
+        .normalised()
+        .iter()
+        .map(|v| format!("{v:.10}"))
+        .collect();
+
+    writeln!(out, "{}<- c({})", sample_name, normalised.join(","))?;
+    writeln!(out, "x <- 1:{NUM_BINS}")?;
+    writeln!(out, "pdf(\"{output_prefix}.geneBodyCoverage.curves.pdf\")")?;
+    writeln!(
+        out,
+        "plot(x,{sample_name},type='l',xlab=\"Gene body percentile (5'->3')\",\
+         ylab=\"Coverage\",lwd=0.8,col=\"blue\")"
+    )?;
+    writeln!(out, "dev.off()")?;
+
+    Ok(())
+}
+
+// ===================================================================
+// Tests
+// ===================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_percentile_positions_matches_upstream_formula() {
+        // 200 contiguous positions 1..=200: k = 199 * i / 100
+        let bases: Vec<u64> = (1..=200).collect();
+        let per = percentile_positions(&bases);
+        assert_eq!(per.len(), 100);
+        // i=1  -> k=1.99  -> interpolate between bases[1]=2 and bases[2]=3
+        //         d0 = 2*(2-1.99)=0.02, d1 = 3*(1.99-1)=2.97 -> round(2.99)=3
+        assert_eq!(per[0], 3);
+        // i=100 -> k=199 (integral) -> bases[199] = 200
+        assert_eq!(per[99], 200);
+        // Monotonically non-decreasing
+        assert!(per.windows(2).all(|w| w[0] <= w[1]));
+    }
+
+    #[test]
+    fn test_round_half_to_even_matches_python() {
+        // Python's round(): 0.5 -> 0, 1.5 -> 2, 2.5 -> 2, 3.5 -> 4
+        assert_eq!(round_half_to_even(0.5), 0.0);
+        assert_eq!(round_half_to_even(1.5), 2.0);
+        assert_eq!(round_half_to_even(2.5), 2.0);
+        assert_eq!(round_half_to_even(3.5), 4.0);
+        // Non-half values round normally
+        assert_eq!(round_half_to_even(2.4), 2.0);
+        assert_eq!(round_half_to_even(2.6), 3.0);
+    }
+
+    #[test]
+    fn test_percentile_positions_short_list_returned_unchanged() {
+        let bases: Vec<u64> = (1..=50).collect();
+        assert_eq!(percentile_positions(&bases), bases);
+    }
+
+    #[test]
+    fn test_percentile_positions_spans_exon_junctions() {
+        // Two exons: 1..=100 and 1001..=1100. Interpolated points may land in
+        // the intron — upstream behaves the same way.
+        let mut bases: Vec<u64> = (1..=100).collect();
+        bases.extend(1001..=1100);
+        let per = percentile_positions(&bases);
+        assert_eq!(per.len(), 100);
+        assert_eq!(per[99], 1100, "last percentile is the 3'-most base");
+        assert!(per[0] < 100, "first percentile is inside the first exon");
+    }
+
+    /// Build a single-gene index and count coverage from a handful of reads.
+    fn single_gene_index(strand: char) -> (IndexMap<String, Gene>, GeneBodyIndex) {
+        use crate::gtf::{Exon, Transcript};
+        let exons = vec![Exon {
+            chrom: "chr1".to_string(),
+            start: 1,
+            end: 1000,
+            strand,
+        }];
+        let gene = Gene {
+            gene_id: "G1".to_string(),
+            chrom: "chr1".to_string(),
+            start: 1,
+            end: 1000,
+            strand,
+            exons,
+            effective_length: 1000,
+            attributes: Default::default(),
+            transcripts: vec![Transcript {
+                transcript_id: "T1".to_string(),
+                chrom: "chr1".to_string(),
+                start: 1,
+                end: 1000,
+                strand,
+                exons: vec![(1, 1000)],
+                cds_start: None,
+                cds_end: None,
+            }],
+        };
+        let mut genes = IndexMap::new();
+        genes.insert("G1".to_string(), gene);
+        let index = GeneBodyIndex::from_genes(&genes);
+        (genes, index)
+    }
+
+    #[test]
+    fn test_coverage_profile_forward_strand() {
+        use rust_htslib::bam::Read as BamRead;
+        let (_genes, index) = single_gene_index('+');
+        assert_eq!(index.num_transcripts(), 1);
+
+        // One read covering positions 1..=50 (the 5' end of the transcript)
+        let sam = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:20000\n\
+r1\t0\tchr1\t1\t60\t50M\t*\t0\t0\t*\t*\n";
+        let path = std::env::temp_dir().join(format!(
+            "rustqc_gbc_fwd_{:?}.sam",
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, sam).unwrap();
+
+        let mut reader = bam::Reader::from_path(&path).unwrap();
+        let mut accum = GeneBodyCoverageAccum::new(&index);
+        let mut record = bam::Record::new();
+        while let Some(res) = reader.read(&mut record) {
+            res.unwrap();
+            accum.process_read(&record, "CHR1", &index);
+        }
+        let _ = std::fs::remove_file(&path);
+
+        let result = accum.into_result(&index);
+        let covered: u64 = result.coverage.iter().sum();
+        assert!(covered > 0, "read should cover sampled positions");
+        // Coverage must sit at the 5' end for a + strand transcript
+        let first_half: u64 = result.coverage[..50].iter().sum();
+        let second_half: u64 = result.coverage[50..].iter().sum();
+        assert_eq!(second_half, 0, "no coverage expected in the 3' half");
+        assert_eq!(first_half, covered);
+    }
+
+    #[test]
+    fn test_coverage_profile_reverse_strand_is_flipped() {
+        use rust_htslib::bam::Read as BamRead;
+        let (_genes, index) = single_gene_index('-');
+
+        // Same read at the low-coordinate end; on a - strand transcript that is
+        // the 3' end, so coverage must land in the high bins.
+        let sam = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:20000\n\
+r1\t0\tchr1\t1\t60\t50M\t*\t0\t0\t*\t*\n";
+        let path = std::env::temp_dir().join(format!(
+            "rustqc_gbc_rev_{:?}.sam",
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, sam).unwrap();
+
+        let mut reader = bam::Reader::from_path(&path).unwrap();
+        let mut accum = GeneBodyCoverageAccum::new(&index);
+        let mut record = bam::Record::new();
+        while let Some(res) = reader.read(&mut record) {
+            res.unwrap();
+            accum.process_read(&record, "CHR1", &index);
+        }
+        let _ = std::fs::remove_file(&path);
+
+        let result = accum.into_result(&index);
+        let first_half: u64 = result.coverage[..50].iter().sum();
+        let second_half: u64 = result.coverage[50..].iter().sum();
+        assert_eq!(first_half, 0, "5' end is the high-coordinate end here");
+        assert!(second_half > 0);
+    }
+
+    #[test]
+    fn test_short_transcripts_are_skipped() {
+        use crate::gtf::Exon;
+        let gene = Gene {
+            gene_id: "G_short".to_string(),
+            chrom: "chr1".to_string(),
+            start: 1,
+            end: 50,
+            strand: '+',
+            exons: vec![Exon {
+                chrom: "chr1".to_string(),
+                start: 1,
+                end: 50,
+                strand: '+',
+            }],
+            effective_length: 50,
+            attributes: Default::default(),
+            transcripts: Vec::new(),
+        };
+        let mut genes = IndexMap::new();
+        genes.insert("G_short".to_string(), gene);
+        let index = GeneBodyIndex::from_genes(&genes);
+        assert!(
+            index.is_empty(),
+            "50 bp transcript is below the 100 bp cutoff"
+        );
+    }
+}

--- a/src/rna/rseqc/mod.rs
+++ b/src/rna/rseqc/mod.rs
@@ -9,6 +9,7 @@ pub mod plots;
 
 pub mod bam_stat;
 pub mod flagstat;
+pub mod gene_body_coverage;
 pub mod idxstats;
 pub mod infer_experiment;
 pub mod inner_distance;
@@ -16,5 +17,6 @@ pub mod junction_annotation;
 pub mod junction_saturation;
 pub mod read_distribution;
 pub mod read_duplication;
+pub mod read_gc;
 pub mod stats;
 pub mod tin;

--- a/src/rna/rseqc/plots.rs
+++ b/src/rna/rseqc/plots.rs
@@ -10,10 +10,12 @@ use plotters::prelude::*;
 use plotters_svg::SVGBackend;
 use std::path::Path;
 
+use super::gene_body_coverage::GeneBodyCoverageResult;
 use super::inner_distance::InnerDistanceResult;
 use super::junction_annotation::JunctionResults;
 use super::junction_saturation::SaturationResult;
 use super::read_duplication::ReadDuplicationResult;
+use super::read_gc::ReadGcResult;
 
 // ============================================================================
 // Constants
@@ -1248,4 +1250,169 @@ mod tests {
             integral
         );
     }
+}
+
+// ============================================================================
+// Gene body coverage
+// ============================================================================
+
+/// Generate the gene body coverage curve as PNG and SVG.
+///
+/// # Arguments
+/// * `result` - The aggregated 100-bin coverage profile
+/// * `sample_name` - Sample name used as the plot caption
+/// * `output_path` - PNG output path (the SVG uses the same stem)
+pub fn gene_body_coverage_plot(
+    result: &GeneBodyCoverageResult,
+    sample_name: &str,
+    output_path: &Path,
+) -> Result<()> {
+    {
+        let root = BitMapBackend::new(output_path, (s(WIDTH), s(HEIGHT))).into_drawing_area();
+        render_gene_body_coverage(&root, result, sample_name, SCALE as f64)?;
+        root.present()
+            .context("Failed to write gene body coverage PNG")?;
+    }
+
+    let svg_path = output_path.with_extension("svg");
+    {
+        let root = SVGBackend::new(&svg_path, (WIDTH, HEIGHT)).into_drawing_area();
+        render_gene_body_coverage(&root, result, sample_name, 1.0)?;
+        root.present()
+            .context("Failed to write gene body coverage SVG")?;
+    }
+
+    debug!("Wrote gene body coverage plot: {}", output_path.display());
+    Ok(())
+}
+
+/// Render the 5' → 3' coverage curve.
+///
+/// Replicates the upstream RSeQC curve plot, which draws normalised coverage
+/// against the gene body percentile:
+/// ```r
+/// plot(x, sample, type='l', xlab="Gene body percentile (5'->3')", ylab="Coverage")
+/// ```
+fn render_gene_body_coverage<DB: DrawingBackend>(
+    root: &DrawingArea<DB, plotters::coord::Shift>,
+    result: &GeneBodyCoverageResult,
+    sample_name: &str,
+    pxs: f64,
+) -> Result<()>
+where
+    DB::ErrorType: 'static,
+{
+    let ps = |v: f64| (v * pxs) as u32;
+
+    root.fill(&WHITE)?;
+
+    let values = result.normalised();
+    if values.is_empty() {
+        return Ok(());
+    }
+
+    let mut chart = ChartBuilder::on(root)
+        .margin(ps(10.0))
+        .x_label_area_size(ps(35.0))
+        .y_label_area_size(ps(50.0))
+        .caption(sample_name, ("sans-serif", ps(14.0)))
+        .build_cartesian_2d(1.0_f64..100.0_f64, 0.0_f64..1.05_f64)?;
+
+    chart
+        .configure_mesh()
+        .disable_mesh()
+        .x_desc("Gene body percentile (5'->3')")
+        .y_desc("Coverage")
+        .axis_style(BLACK.stroke_width(ps(1.0).max(1)))
+        .label_style(("sans-serif", ps(11.0)))
+        .draw()?;
+
+    chart.draw_series(LineSeries::new(
+        values.iter().enumerate().map(|(i, &v)| ((i + 1) as f64, v)),
+        BLUE.stroke_width(ps(1.5).max(1)),
+    ))?;
+
+    Ok(())
+}
+
+// ============================================================================
+// Read GC content
+// ============================================================================
+
+/// Generate the read GC content distribution as PNG and SVG.
+///
+/// # Arguments
+/// * `result` - The GC distribution
+/// * `sample_name` - Sample name used as the plot caption
+/// * `output_path` - PNG output path (the SVG uses the same stem)
+pub fn read_gc_plot(result: &ReadGcResult, sample_name: &str, output_path: &Path) -> Result<()> {
+    {
+        let root = BitMapBackend::new(output_path, (s(WIDTH), s(HEIGHT))).into_drawing_area();
+        render_read_gc(&root, result, sample_name, SCALE as f64)?;
+        root.present().context("Failed to write read GC PNG")?;
+    }
+
+    let svg_path = output_path.with_extension("svg");
+    {
+        let root = SVGBackend::new(&svg_path, (WIDTH, HEIGHT)).into_drawing_area();
+        render_read_gc(&root, result, sample_name, 1.0)?;
+        root.present().context("Failed to write read GC SVG")?;
+    }
+
+    debug!("Wrote read GC plot: {}", output_path.display());
+    Ok(())
+}
+
+/// Render the GC distribution as reads-per-GC-percent, binned to 1% steps.
+///
+/// Upstream plots a density histogram over the per-read GC values; binning the
+/// sparse distribution to 1% steps gives the same shape without needing to
+/// materialise one value per read.
+fn render_read_gc<DB: DrawingBackend>(
+    root: &DrawingArea<DB, plotters::coord::Shift>,
+    result: &ReadGcResult,
+    sample_name: &str,
+    pxs: f64,
+) -> Result<()>
+where
+    DB::ErrorType: 'static,
+{
+    let ps = |v: f64| (v * pxs) as u32;
+
+    root.fill(&WHITE)?;
+
+    if result.distribution.is_empty() {
+        return Ok(());
+    }
+
+    // Bin to whole-percent buckets for plotting
+    let mut bins = [0u64; 101];
+    for &(pct, count) in &result.distribution {
+        let idx = (pct.round() as usize).min(100);
+        bins[idx] += count;
+    }
+    let y_max = bins.iter().copied().max().unwrap_or(1) as f64;
+
+    let mut chart = ChartBuilder::on(root)
+        .margin(ps(10.0))
+        .x_label_area_size(ps(35.0))
+        .y_label_area_size(ps(60.0))
+        .caption(sample_name, ("sans-serif", ps(14.0)))
+        .build_cartesian_2d(0.0_f64..100.0_f64, 0.0_f64..(y_max * 1.05))?;
+
+    chart
+        .configure_mesh()
+        .disable_mesh()
+        .x_desc("GC content (%)")
+        .y_desc("Number of reads")
+        .axis_style(BLACK.stroke_width(ps(1.0).max(1)))
+        .label_style(("sans-serif", ps(11.0)))
+        .draw()?;
+
+    chart.draw_series(LineSeries::new(
+        bins.iter().enumerate().map(|(i, &c)| (i as f64, c as f64)),
+        BLUE.stroke_width(ps(1.5).max(1)),
+    ))?;
+
+    Ok(())
 }

--- a/src/rna/rseqc/read_gc.rs
+++ b/src/rna/rseqc/read_gc.rs
@@ -1,0 +1,326 @@
+//! GC content distribution of mapped reads.
+//!
+//! Reimplementation of RSeQC's `read_GC.py`. For every read passing the
+//! filters, the GC percentage of the query sequence is computed and binned;
+//! the distribution is the standard check for GC bias introduced by library
+//! preparation or sequencing.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use log::debug;
+use rust_htslib::bam;
+
+use crate::rna::bam_flags::{BAM_FQCFAIL, BAM_FUNMAP};
+
+/// Number of GC-percentage buckets: one per 0.01% step over [0, 100].
+///
+/// RSeQC formats the percentage with `"%4.2f"`, so two decimal places is the
+/// full resolution of its output keys.
+const GC_BUCKETS: usize = 10_001;
+
+// ===================================================================
+// Accumulator
+// ===================================================================
+
+/// Per-worker accumulator for the read GC distribution.
+///
+/// Reads are filtered exactly as RSeQC's `ParseBAM.readGC` does: unmapped and
+/// QC-failed records are skipped, along with records below the MAPQ cutoff.
+/// Secondary alignments and duplicates are deliberately *not* filtered —
+/// upstream does not filter them either.
+#[derive(Debug, Clone)]
+pub struct ReadGcAccum {
+    /// Counts indexed by `round(gc_percent * 100)`.
+    counts: Vec<u64>,
+    /// MAPQ cutoff below which reads are ignored.
+    mapq_cut: u8,
+    /// Reads skipped because they carried no query sequence.
+    pub missing_sequence: u64,
+}
+
+impl ReadGcAccum {
+    /// Create an accumulator with the given MAPQ cutoff.
+    pub fn new(mapq_cut: u8) -> Self {
+        Self {
+            counts: vec![0; GC_BUCKETS],
+            mapq_cut,
+            missing_sequence: 0,
+        }
+    }
+
+    /// Process a single alignment record.
+    pub fn process_read(&mut self, record: &bam::Record) {
+        let flags = record.flags();
+        if flags & (BAM_FUNMAP | BAM_FQCFAIL) != 0 {
+            return;
+        }
+        if record.mapq() < self.mapq_cut {
+            return;
+        }
+
+        let seq = record.seq();
+        let len = seq.len();
+        if len == 0 {
+            // Records stored without SEQ ('*'). Upstream would divide by zero
+            // here; we skip them and report the count instead.
+            self.missing_sequence += 1;
+            return;
+        }
+
+        let mut gc = 0u64;
+        for i in 0..len {
+            // seq() decodes to uppercase IUPAC bytes
+            if matches!(seq[i], b'C' | b'G' | b'c' | b'g') {
+                gc += 1;
+            }
+        }
+
+        let pct = 100.0 * gc as f64 / len as f64;
+        let bucket = (pct * 100.0).round() as usize;
+        // pct <= 100 so bucket <= 10000, but clamp defensively
+        self.counts[bucket.min(GC_BUCKETS - 1)] += 1;
+    }
+
+    /// Merge another worker's counts into this accumulator.
+    pub fn merge(&mut self, other: ReadGcAccum) {
+        for (a, b) in self.counts.iter_mut().zip(other.counts.iter()) {
+            *a += b;
+        }
+        self.missing_sequence += other.missing_sequence;
+    }
+
+    /// Finalise into a sorted distribution.
+    pub fn into_result(self) -> ReadGcResult {
+        let distribution: Vec<(f64, u64)> = self
+            .counts
+            .iter()
+            .enumerate()
+            .filter(|(_, &count)| count > 0)
+            .map(|(bucket, &count)| (bucket as f64 / 100.0, count))
+            .collect();
+        ReadGcResult {
+            distribution,
+            missing_sequence: self.missing_sequence,
+        }
+    }
+}
+
+/// GC distribution over all processed reads.
+#[derive(Debug, Clone)]
+pub struct ReadGcResult {
+    /// `(gc_percent, read_count)` pairs, ascending by GC percentage.
+    ///
+    /// Only non-empty buckets are kept, matching upstream's sparse dictionary.
+    pub distribution: Vec<(f64, u64)>,
+    /// Reads skipped because they carried no query sequence.
+    pub missing_sequence: u64,
+}
+
+impl ReadGcResult {
+    /// Total reads contributing to the distribution.
+    pub fn total_reads(&self) -> u64 {
+        self.distribution.iter().map(|&(_, c)| c).sum()
+    }
+
+    /// Mean GC percentage across all reads, or `None` when empty.
+    pub fn mean_gc(&self) -> Option<f64> {
+        let total = self.total_reads();
+        if total == 0 {
+            return None;
+        }
+        let sum: f64 = self
+            .distribution
+            .iter()
+            .map(|&(pct, count)| pct * count as f64)
+            .sum();
+        Some(sum / total as f64)
+    }
+
+    /// Distribution as a `HashMap` keyed by the formatted percentage, matching
+    /// upstream's output keys.
+    pub fn as_map(&self) -> HashMap<String, u64> {
+        self.distribution
+            .iter()
+            .map(|&(pct, count)| (format!("{pct:.2}"), count))
+            .collect()
+    }
+}
+
+// ===================================================================
+// Output
+// ===================================================================
+
+/// Write the `.GC.xls` distribution table.
+///
+/// Format matches RSeQC: a `GC%\tread_count` header followed by one row per
+/// observed GC percentage. Rows are sorted ascending by GC percentage
+/// (upstream emits Python dictionary order, which is BAM-order dependent and
+/// therefore not reproducible under parallel processing).
+pub fn write_gc_table(result: &ReadGcResult, output_path: &Path) -> Result<()> {
+    let mut out = std::fs::File::create(output_path)
+        .with_context(|| format!("Failed to create GC table: {}", output_path.display()))?;
+
+    writeln!(out, "GC%\tread_count")?;
+    for &(pct, count) in &result.distribution {
+        writeln!(out, "{pct:.2}\t{count}")?;
+    }
+
+    debug!(
+        "Wrote read GC distribution to {} ({} buckets)",
+        output_path.display(),
+        result.distribution.len()
+    );
+    Ok(())
+}
+
+/// Write the R plotting script RSeQC produces alongside the table.
+///
+/// RustQC renders the plot itself; the script is written for drop-in
+/// compatibility with pipelines that expect it.
+pub fn write_gc_r_script(
+    result: &ReadGcResult,
+    output_prefix: &str,
+    output_path: &Path,
+) -> Result<()> {
+    let mut out = std::fs::File::create(output_path)
+        .with_context(|| format!("Failed to create GC R script: {}", output_path.display()))?;
+
+    // Emit the distribution as rep(values, times=counts) rather than one entry
+    // per read: identical to upstream's vector, but linear in the number of
+    // distinct GC values instead of the number of reads.
+    writeln!(out, "pdf(\"{output_prefix}.GC_plot.pdf\")")?;
+    writeln!(
+        out,
+        "gc=rep(c({}),times=c({}))",
+        result
+            .distribution
+            .iter()
+            .map(|&(pct, _)| format!("{pct:.2}"))
+            .collect::<Vec<_>>()
+            .join(","),
+        result
+            .distribution
+            .iter()
+            .map(|&(_, count)| count.to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+    )?;
+    writeln!(out, "hist(gc,probability=T,breaks=100,xlab=\"GC content (%)\",ylab=\"Density of Reads\",border=\"blue\",main=\"\")")?;
+    writeln!(out, "lines(density(gc),col='red')")?;
+    writeln!(out, "dev.off()")?;
+
+    debug!("Wrote read GC R script to {}", output_path.display());
+    Ok(())
+}
+
+// ===================================================================
+// Tests
+// ===================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_htslib::bam::Read as BamRead;
+
+    fn write_temp_sam(content: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "rustqc_read_gc_test_{:?}_{}.sam",
+            std::thread::current().id(),
+            id
+        ));
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    fn accumulate(sam: &str, mapq_cut: u8) -> ReadGcResult {
+        let path = write_temp_sam(sam);
+        let mut reader = bam::Reader::from_path(&path).unwrap();
+        let mut accum = ReadGcAccum::new(mapq_cut);
+        let mut record = bam::Record::new();
+        while let Some(res) = reader.read(&mut record) {
+            res.unwrap();
+            accum.process_read(&record);
+        }
+        let _ = std::fs::remove_file(&path);
+        accum.into_result()
+    }
+
+    #[test]
+    fn test_gc_percentages_and_filters() {
+        // r1: GCGCGCGCGC -> 100.00
+        // r2: ACGTACGTAC -> 50.00
+        // r3: AAAAAAAAAA -> 0.00
+        // r4: MAPQ 5, below the cutoff -> skipped
+        // r5: QC-fail (0x200) -> skipped
+        // r6: unmapped (0x4) -> skipped
+        let sam = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:20000\n\
+r1\t0\tchr1\t100\t60\t10M\t*\t0\t0\tGCGCGCGCGC\tIIIIIIIIII\n\
+r2\t0\tchr1\t120\t60\t10M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII\n\
+r3\t0\tchr1\t140\t60\t10M\t*\t0\t0\tAAAAAAAAAA\tIIIIIIIIII\n\
+r4\t0\tchr1\t160\t5\t10M\t*\t0\t0\tGCGCGCGCGC\tIIIIIIIIII\n\
+r5\t512\tchr1\t180\t60\t10M\t*\t0\t0\tGCGCGCGCGC\tIIIIIIIIII\n\
+r6\t4\tchr1\t200\t0\t*\t*\t0\t0\tGCGCGCGCGC\tIIIIIIIIII\n";
+
+        let result = accumulate(sam, 30);
+        assert_eq!(result.total_reads(), 3, "three reads pass the filters");
+
+        let map = result.as_map();
+        assert_eq!(map.get("100.00"), Some(&1));
+        assert_eq!(map.get("50.00"), Some(&1));
+        assert_eq!(map.get("0.00"), Some(&1));
+        assert_eq!(map.len(), 3);
+
+        // Ascending order
+        let pcts: Vec<f64> = result.distribution.iter().map(|&(p, _)| p).collect();
+        assert_eq!(pcts, vec![0.0, 50.0, 100.0]);
+
+        let mean = result.mean_gc().unwrap();
+        assert!((mean - 50.0).abs() < 1e-9, "mean GC: {mean}");
+    }
+
+    #[test]
+    fn test_secondary_and_duplicate_reads_are_counted() {
+        // Upstream readGC does not filter secondary alignments or duplicates.
+        // r1 secondary (0x100), r2 duplicate (0x400)
+        let sam = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:20000\n\
+r1\t256\tchr1\t100\t60\t10M\t*\t0\t0\tGCGCGCGCGC\tIIIIIIIIII\n\
+r2\t1024\tchr1\t120\t60\t10M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII\n";
+
+        let result = accumulate(sam, 30);
+        assert_eq!(result.total_reads(), 2);
+    }
+
+    #[test]
+    fn test_reads_without_sequence_are_reported() {
+        let sam = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:20000\n\
+r1\t0\tchr1\t100\t60\t10M\t*\t0\t0\t*\t*\n";
+
+        let result = accumulate(sam, 30);
+        assert_eq!(result.total_reads(), 0);
+        assert_eq!(result.missing_sequence, 1);
+    }
+
+    #[test]
+    fn test_merge_combines_distributions() {
+        let mut a = ReadGcAccum::new(0);
+        let mut b = ReadGcAccum::new(0);
+        a.counts[5000] = 3;
+        b.counts[5000] = 4;
+        b.counts[10000] = 1;
+        a.merge(b);
+        let result = a.into_result();
+        assert_eq!(result.distribution, vec![(50.0, 7), (100.0, 1)]);
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1026,3 +1026,101 @@ fn test_dup_check_parallel_uses_global_duplicate_state() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+// ============================================================================
+// Gene body coverage / read GC (RSeQC geneBody_coverage.py / read_GC.py)
+// ============================================================================
+
+/// Reference gene body coverage profile for `tests/data/test.bam`.
+///
+/// Produced by RSeQC 5.05 (`geneBody_coverage.py`) using a BED12 file built
+/// from `tests/data/test.gtf` with the same representative-transcript choice
+/// RustQC makes (the transcript with the most exonic bases per gene).
+const EXPECTED_GENE_BODY_COVERAGE: [u64; 100] = [
+    4, 10, 15, 15, 14, 17, 14, 13, 17, 16, //
+    15, 19, 20, 19, 24, 24, 32, 35, 35, 29, //
+    29, 30, 34, 35, 40, 35, 30, 29, 29, 30, //
+    32, 34, 33, 31, 29, 29, 31, 37, 38, 35, //
+    33, 37, 44, 49, 50, 52, 52, 48, 47, 53, //
+    53, 52, 49, 44, 43, 43, 45, 50, 48, 50, //
+    52, 56, 52, 48, 45, 43, 40, 38, 38, 37, //
+    38, 38, 34, 28, 35, 34, 35, 35, 32, 32, //
+    33, 28, 29, 27, 25, 19, 22, 20, 22, 21, //
+    25, 27, 26, 21, 21, 17, 16, 13, 10, 1, //
+];
+
+#[test]
+fn test_gene_body_coverage_matches_rseqc() {
+    let root = unique_test_dir("genebody");
+    let outdir = root.display().to_string();
+    let output = run_rustqc(&outdir);
+    assert!(
+        output.status.success(),
+        "rustqc failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let path = format!("{outdir}/rseqc/gene_body_coverage/test.geneBodyCoverage.txt");
+    let contents = fs::read_to_string(&path).expect("geneBodyCoverage.txt not written");
+    let mut lines = contents.lines();
+
+    let header = lines.next().expect("missing header line");
+    let expected_header: String = std::iter::once("Percentile".to_string())
+        .chain((1..=100).map(|i| i.to_string()))
+        .collect::<Vec<_>>()
+        .join("\t");
+    assert_eq!(header, expected_header, "header must match RSeQC format");
+
+    let data = lines.next().expect("missing sample line");
+    let mut fields = data.split('\t');
+    assert_eq!(
+        fields.next(),
+        Some("test"),
+        "first column is the sample name"
+    );
+
+    let values: Vec<f64> = fields
+        .map(|v| v.parse::<f64>().expect("coverage value must parse"))
+        .collect();
+    assert_eq!(values.len(), 100, "expected 100 percentile bins");
+
+    for (i, (&got, &want)) in values
+        .iter()
+        .zip(EXPECTED_GENE_BODY_COVERAGE.iter())
+        .enumerate()
+    {
+        assert_eq!(
+            got,
+            want as f64,
+            "bin {} differs from the RSeQC reference",
+            i + 1
+        );
+    }
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn test_read_gc_table_matches_rseqc() {
+    let root = unique_test_dir("readgc");
+    let outdir = root.display().to_string();
+    let output = run_rustqc(&outdir);
+    assert!(
+        output.status.success(),
+        "rustqc failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let path = format!("{outdir}/rseqc/read_gc/test.GC.xls");
+    let contents = fs::read_to_string(&path).expect("GC.xls not written");
+
+    // Every read in tests/data/test.bam is poly-A, so RSeQC 5.05 reports a
+    // single 0.00% bucket holding all 483 reads that pass its filters.
+    assert_eq!(
+        contents.trim(),
+        "GC%\tread_count\n0.00\t483",
+        "GC table must match the RSeQC reference"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Closes #127.

Adds the two remaining RSeQC tools, both inside the existing single pass.

## geneBody_coverage

`src/rna/rseqc/gene_body_coverage.rs` — 5' → 3' coverage in 100 percentile bins.

- Each transcript's exonic bases are reduced to 100 percentile positions with a direct port of RSeQC's `mystat.percentile_list`
- Reverse-strand transcripts are flipped so bin 1 is always the 5' end
- Transcripts under 100 bp are skipped (RSeQC's `--minimum_length` default)
- Read filters: unmapped, QC-fail, secondary, duplicate; deletions and `N` skips do not count as covered

Outputs `{sample}.geneBodyCoverage.txt` (RSeQC format), `.geneBodyCoverage.r`, and a native `.curves.png`/`.svg`.

One deliberate deviation, documented in the docs and module: RSeQC profiles every entry of a BED12 reference (usually a housekeeping-gene set); RustQC has no BED input here and profiles one representative transcript per gene from the GTF — the one with the most exonic bases, the same choice the TIN analysis already makes.

⚠️ Worth a maintainer's eye: the port needs **Python's round-half-to-even**. With `f64::round` (half away from zero), interpolated percentile positions land one base off and 7 of 100 bins came out ±1 against upstream. There's a unit test pinning the rounding behaviour and a note in AGENTS.md.

## read_GC

`src/rna/rseqc/read_gc.rs` — GC distribution of mapped reads.

- Filters match upstream `ParseBAM.readGC`: skip unmapped, QC-fail and below the MAPQ cutoff; secondary alignments and duplicates **are** counted (upstream does not filter them)
- GC percentage formatted to two decimals, as upstream does

Outputs `{sample}.GC.xls`, `.GC_plot.r`, and a native `.GC_plot.png`/`.svg`.

Two deliberate deviations: rows are sorted ascending by GC percentage (upstream emits Python dict order, which is BAM-order dependent and not reproducible under parallel processing), and reads stored without `SEQ` are skipped with a warning instead of dividing by zero.

## Validation against RSeQC 5.05

Ran upstream `geneBody_coverage.py` and `read_GC.py` (RSeQC 5.05, pysam) on `tests/data/test.bam`, using a BED12 built from `tests/data/test.gtf` with the same representative-transcript choice:

- gene body coverage: **all 100 bins identical**
- GC table: **identical** (`0.00	483`)

Both references are pinned in new integration tests. Also verified `--threads 4` produces byte-identical output to single-threaded, and that the skip flags remove the outputs.

## Other

- Config: `rna.gene_body_coverage.enabled`, `rna.read_gc.enabled` (both default `true`); CLI `--skip-gene-body-coverage`, `--skip-read-gc`
- Docs: new sections on the RSeQC page (including a note on how this differs from the Qualimap gene body coverage RustQC already produces), config/CLI reference entries, "8 RSeQC tools" → 10 where claimed
- `cargo test` — 211 lib + 20 integration tests pass; `cargo fmt --check`, `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)