### PR TITLE
feat: add bamqc subcommand for generic genomic BAM/CRAM QC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,10 @@ src/
   config.rs         — YAML configuration loading (serde), nested tool configs
   io.rs             — Shared I/O utilities (gzip-transparent file reading)
   gtf.rs            — GTF annotation file parser (with configurable attribute extraction)
+  bamqc/
+    mod.rs          — Re-exports the bamqc accumulator and writers
+    accumulator.rs  — Single-pass generic BAM QC metrics (exact per-base depth)
+    output.rs       — Qualimap bamqc-compatible output files
   rna/
     mod.rs          — Re-exports all submodules (dupradar, featurecounts, rseqc, bam_flags, cpp_rng, preseq, qualimap)
     bam_flags.rs    — BAM flag constants
@@ -111,9 +115,11 @@ Nested module structure — top-level modules (`cli`, `config`, `io`, `gtf`, `rn
 in `main.rs`, no `lib.rs`. The `rna` module contains sub-modules for each tool group.
 Inter-module access uses `crate::` paths (e.g., `use crate::rna::dupradar::counting::GeneCounts;`).
 
-The CLI uses a single subcommand:
+The CLI has two subcommands:
 
 - `rustqc rna <BAM>... --gtf <GTF> [OPTIONS]`
+- `rustqc bamqc <BAM> [OPTIONS]` — generic genomic QC (Qualimap `bamqc` mode),
+  no annotation required
 
 A GTF gene annotation file (`--gtf`) is required. This runs all analyses:
 dupRadar duplicate rate analysis, featureCounts-compatible gene counting,
@@ -273,6 +279,12 @@ Both checks are skipped when `--skip-dup-check` is passed (stored as `RnaArgs.sk
 forwarded to `count_reads()` as the `skip_dup_check: bool` parameter).
 
 ## Notes for Agents
+
+- `rustqc bamqc` streams a coordinate-sorted file once and computes depth exactly
+  via start/end delta events folded in as the file advances — do not replace this
+  with sampling or a per-base array. Coverage excludes secondary alignments and
+  includes duplicates by default (Qualimap's default); `--skip-duplicated` excludes
+  them. Both modes are pinned in integration tests against `samtools depth`.
 
 - A `.pre-commit-config.yaml` is provided for local git hooks (fmt, clippy, file hygiene).
   Use [prek](https://github.com/j178/prek) (`prek install`) or the original

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -73,6 +73,10 @@ export default defineConfig({
           ],
         },
         {
+          label: "Genomic",
+          items: [{ label: "bamqc", slug: "bamqc" }],
+        },
+        {
           label: "About",
           items: [
             {

--- a/docs/src/content/docs/bamqc.mdx
+++ b/docs/src/content/docs/bamqc.mdx
@@ -1,0 +1,112 @@
+---
+title: bamqc
+description: Generic genomic BAM/CRAM quality control — coverage, GC content, insert size and mapping quality, without an annotation file.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+`rustqc bamqc` is the generic-genomic counterpart to `rustqc rna`. It
+reimplements the metrics of [Qualimap](http://qualimap.conesalab.org/)'s
+`bamqc` mode: coverage depth and breadth, GC content, insert size, mapping
+quality and per-contig coverage.
+
+Unlike `rustqc rna`, it needs **no GTF** — nothing here is annotation-driven.
+
+```bash
+rustqc bamqc sample.bam --outdir results/
+rustqc bamqc sample.cram --reference genome.fa --outdir results/
+```
+
+<Aside type="note" title="bamqc vs rnaseq mode">
+Qualimap's two modes measure different things. `rnaseq` mode (which `rustqc rna`
+reimplements) is RNA-seq specific: exonic/intronic/intergenic read origin,
+5'→3' transcript coverage bias, strand specificity, junction analysis — all of
+which require an annotation. `bamqc` mode is generic genomic QC and requires
+none.
+</Aside>
+
+## Options
+
+| Flag                   | Description                                                     |
+| ---------------------- | --------------------------------------------------------------- |
+| `-r, --reference`      | Reference FASTA (required for CRAM input)                       |
+| `-o, --outdir`         | Output directory (default `.`)                                  |
+| `--sample-name`        | Override the sample name (default: input filename stem)         |
+| `-t, --threads`        | htslib decompression threads                                     |
+| `--skip-duplicated`    | Exclude duplicate-flagged reads from all metrics                |
+
+Input must be coordinate-sorted.
+
+## Output files
+
+| File                                                        | Description                                    |
+| ----------------------------------------------------------- | ---------------------------------------------- |
+| `genome_results.txt`                                        | Main summary report                            |
+| `raw_data_qualimapReport/coverage_histogram.txt`            | Depth → number of genomic positions            |
+| `raw_data_qualimapReport/genome_fraction_coverage.txt`      | Cumulative fraction of reference at each depth |
+| `raw_data_qualimapReport/mapped_reads_gc-content_distribution.txt` | Per-read GC distribution                |
+| `raw_data_qualimapReport/mapped_reads_nucleotide_content.txt` | Overall base composition                     |
+| `raw_data_qualimapReport/insert_size_histogram.txt`         | Insert size distribution                       |
+
+The layout and file names match Qualimap's, so MultiQC's Qualimap BamQC module
+picks the results up without changes.
+
+### genome_results.txt
+
+```
+>>>>>>> Reference
+
+     number of bases = 40,000 bp
+     number of contigs = 2
+
+>>>>>>> Globals
+
+     number of reads = 488
+     number of mapped reads = 483 (98.98%)
+     ...
+
+>>>>>>> Coverage
+
+     mean coverageData = 0.6038X
+     std coverageData = 3.2386X
+
+     There is a 12.16% of reference with a coverageData >= 1X
+     There is a 4.78% of reference with a coverageData >= 5X
+     ...
+
+>>>>>>> Coverage per contig
+
+	chr1	20000	13150	0.6575000000	1.8663316292
+	chr2	20000	11000	0.5500000000	4.1819014814
+```
+
+## Metric definitions
+
+Coverage is computed exactly, not sampled: each read contributes `+1` over
+every aligned block (`M`/`=`/`X`/`D`), while `N` skips leave a gap. Because
+input is coordinate-sorted, depth is finalised as the file streams past, so
+memory stays proportional to read pile-up depth rather than to genome size.
+
+- **mean / std coverageData** — over the full reference, counting uncovered
+  bases as zero
+- **fraction ≥ N×** — reference bases at depth ≥ N, as a percentage of total
+  reference length
+- **Coverage per contig** — name, length, aligned bases, mean depth, standard
+  deviation
+
+Secondary alignments are excluded from coverage. Duplicate-flagged reads are
+**included** by default, matching Qualimap; `--skip-duplicated` excludes them.
+
+Both settings were cross-checked against `samtools depth` on the test dataset:
+
+| Mode                | RustQC                     | samtools                                     |
+| ------------------- | -------------------------- | -------------------------------------------- |
+| default             | mean 0.6038X, 12.16% ≥ 1X  | `samtools depth -a -J -g DUP` → same values  |
+| `--skip-duplicated` | mean 0.4325X, 11.55% ≥ 1X  | `samtools depth -a -J` → same values         |
+
+<Aside type="caution" title="Not covered">
+This is the metrics subset, not the whole of Qualimap `bamqc`. There is no HTML
+report, no per-window coverage track, no clipping profile, no homopolymer indel
+breakdown, and no PCR-bias / chimerism estimates. Coverage over a target BED
+(`--feature-file`) is also not supported yet.
+</Aside>

--- a/src/bamqc/accumulator.rs
+++ b/src/bamqc/accumulator.rs
@@ -1,0 +1,694 @@
+//! Single-pass accumulation of generic BAM QC metrics.
+//!
+//! Collects the statistics Qualimap's `bamqc` mode reports: global read
+//! counters, per-base coverage (genome-wide and per contig), insert size,
+//! mapping quality, read length and base composition. No annotation is
+//! required — this is genomic QC, not RNA-seq QC.
+
+use std::collections::{BTreeMap, HashMap};
+
+use rust_htslib::bam::{self, record::Cigar};
+
+use crate::rna::bam_flags::*;
+
+/// Coverage thresholds reported as "fraction of reference covered ≥ N×".
+pub const COVERAGE_THRESHOLDS: [u32; 7] = [1, 5, 10, 20, 30, 40, 50];
+
+// ===================================================================
+// Depth tracking
+// ===================================================================
+
+/// Running summary of per-base depth over one contig.
+#[derive(Debug, Default, Clone)]
+struct DepthSummary {
+    /// depth → number of reference bases at that depth (depth ≥ 1 only).
+    hist: HashMap<u32, u64>,
+    /// Σ depth over covered bases.
+    sum_depth: u128,
+    /// Σ depth² over covered bases.
+    sum_sq: u128,
+    /// Number of reference bases with depth ≥ 1.
+    covered: u64,
+}
+
+impl DepthSummary {
+    fn record(&mut self, depth: u32, span: u64) {
+        if depth == 0 || span == 0 {
+            return;
+        }
+        *self.hist.entry(depth).or_insert(0) += span;
+        self.sum_depth += depth as u128 * span as u128;
+        self.sum_sq += (depth as u128).pow(2) * span as u128;
+        self.covered += span;
+    }
+
+    fn merge(&mut self, other: &DepthSummary) {
+        for (&depth, &span) in &other.hist {
+            *self.hist.entry(depth).or_insert(0) += span;
+        }
+        self.sum_depth += other.sum_depth;
+        self.sum_sq += other.sum_sq;
+        self.covered += other.covered;
+    }
+}
+
+/// Exact per-base depth accumulator for a coordinate-sorted alignment file.
+///
+/// Reads contribute `+1` at the start and `-1` at the end of every aligned
+/// block (`M`/`=`/`X`/`D`; `N` skips leave a gap). Because input is sorted by
+/// start position, every base before the current read's start is final and can
+/// be folded into the summary immediately, so memory stays proportional to the
+/// number of overlapping reads rather than to the contig length.
+#[derive(Debug, Default)]
+struct DepthTracker {
+    /// Pending depth deltas keyed by reference position.
+    events: BTreeMap<u64, i64>,
+    /// Position up to which depth has been folded into the summary.
+    last_pos: u64,
+    /// Current depth at `last_pos`.
+    depth: i64,
+    /// Summary for the contig being processed.
+    current: DepthSummary,
+}
+
+impl DepthTracker {
+    /// Add an aligned block covering `[start, end)` (0-based, half-open).
+    fn add_block(&mut self, start: u64, end: u64) {
+        if end <= start {
+            return;
+        }
+        *self.events.entry(start).or_insert(0) += 1;
+        *self.events.entry(end).or_insert(0) -= 1;
+    }
+
+    /// Fold all depth up to (but excluding) `pos` into the summary.
+    fn advance_to(&mut self, pos: u64) {
+        while let Some((&event_pos, &delta)) = self.events.iter().next() {
+            if event_pos >= pos {
+                break;
+            }
+            if event_pos > self.last_pos {
+                let span = event_pos - self.last_pos;
+                self.current.record(self.depth.max(0) as u32, span);
+            }
+            self.depth += delta;
+            self.last_pos = event_pos;
+            self.events.remove(&event_pos);
+        }
+        if pos > self.last_pos {
+            self.current
+                .record(self.depth.max(0) as u32, pos - self.last_pos);
+            self.last_pos = pos;
+        }
+    }
+
+    /// Fold every remaining event and return the finished contig summary.
+    fn finish_contig(&mut self) -> DepthSummary {
+        let last_event = self.events.keys().next_back().copied().unwrap_or(0);
+        self.advance_to(last_event + 1);
+        self.events.clear();
+        self.depth = 0;
+        self.last_pos = 0;
+        std::mem::take(&mut self.current)
+    }
+}
+
+// ===================================================================
+// Accumulator
+// ===================================================================
+
+/// Collects every metric reported by [`BamqcResult`] in a single pass.
+#[derive(Debug)]
+pub struct BamqcAccum {
+    // --- reference ---
+    /// Contig names and lengths, in header order.
+    contigs: Vec<(String, u64)>,
+    /// Per-contig depth summaries, indexed by tid.
+    contig_depth: Vec<DepthSummary>,
+    /// Per-contig mapped read counts, indexed by tid.
+    contig_reads: Vec<u64>,
+
+    // --- global counters ---
+    total_reads: u64,
+    mapped_reads: u64,
+    unmapped_reads: u64,
+    secondary: u64,
+    supplementary: u64,
+    duplicates: u64,
+    qc_failed: u64,
+    paired_reads: u64,
+    first_in_pair: u64,
+    second_in_pair: u64,
+    both_mates_mapped: u64,
+    singletons: u64,
+
+    // --- lengths and bases ---
+    read_length_min: u64,
+    read_length_max: u64,
+    read_length_sum: u64,
+    read_length_n: u64,
+    /// Bases in the query sequences of mapped reads.
+    sequenced_bases: u64,
+    /// Reference bases covered by aligned blocks (M/=/X/D).
+    aligned_bases: u64,
+    /// Base counts: A, C, G, T, N.
+    base_counts: [u64; 5],
+
+    // --- distributions ---
+    /// GC percentage (rounded to whole percent) → read count.
+    gc_hist: [u64; 101],
+    /// MAPQ → read count (mapped, primary).
+    mapq_hist: [u64; 256],
+    /// abs(TLEN) → pair count, one entry per fragment.
+    insert_hist: BTreeMap<u64, u64>,
+
+    // --- depth state ---
+    depth: DepthTracker,
+    /// tid of the contig currently being tracked.
+    current_tid: i32,
+    /// When true, duplicate-flagged records contribute to nothing but the
+    /// duplicate counter (Qualimap's `--skip-duplicated`).
+    skip_duplicated: bool,
+}
+
+impl BamqcAccum {
+    /// Create an accumulator for a file with the given contigs.
+    ///
+    /// # Arguments
+    /// * `contigs` - Reference names and lengths from the alignment header
+    /// * `skip_duplicated` - Exclude duplicate-flagged records from all metrics
+    pub fn new(contigs: Vec<(String, u64)>, skip_duplicated: bool) -> Self {
+        let n = contigs.len();
+        Self {
+            contigs,
+            contig_depth: vec![DepthSummary::default(); n],
+            contig_reads: vec![0; n],
+            total_reads: 0,
+            mapped_reads: 0,
+            unmapped_reads: 0,
+            secondary: 0,
+            supplementary: 0,
+            duplicates: 0,
+            qc_failed: 0,
+            paired_reads: 0,
+            first_in_pair: 0,
+            second_in_pair: 0,
+            both_mates_mapped: 0,
+            singletons: 0,
+            read_length_min: u64::MAX,
+            read_length_max: 0,
+            read_length_sum: 0,
+            read_length_n: 0,
+            sequenced_bases: 0,
+            aligned_bases: 0,
+            base_counts: [0; 5],
+            gc_hist: [0; 101],
+            mapq_hist: [0; 256],
+            insert_hist: BTreeMap::new(),
+            depth: DepthTracker::default(),
+            current_tid: -1,
+            skip_duplicated,
+        }
+    }
+
+    /// Process one alignment record.
+    ///
+    /// Coverage counts primary mapped alignments (secondary alignments are
+    /// excluded; duplicates are included, matching Qualimap's default of not
+    /// skipping flagged duplicates).
+    pub fn process_read(&mut self, record: &bam::Record) {
+        let flags = record.flags();
+        self.total_reads += 1;
+
+        let is_unmapped = flags & BAM_FUNMAP != 0;
+        let is_secondary = flags & BAM_FSECONDARY != 0;
+        let is_supplementary = flags & BAM_FSUPPLEMENTARY != 0;
+        let is_primary = !is_secondary && !is_supplementary;
+
+        if is_secondary {
+            self.secondary += 1;
+        } else if is_supplementary {
+            self.supplementary += 1;
+        }
+        let is_duplicate = flags & BAM_FDUP != 0;
+        if is_duplicate {
+            self.duplicates += 1;
+            if self.skip_duplicated {
+                return;
+            }
+        }
+        if flags & BAM_FQCFAIL != 0 {
+            self.qc_failed += 1;
+        }
+
+        if is_unmapped {
+            self.unmapped_reads += 1;
+            return;
+        }
+        self.mapped_reads += 1;
+
+        if is_primary {
+            if flags & BAM_FPAIRED != 0 {
+                self.paired_reads += 1;
+                if flags & BAM_FREAD1 != 0 {
+                    self.first_in_pair += 1;
+                }
+                if flags & BAM_FREAD2 != 0 {
+                    self.second_in_pair += 1;
+                }
+                if flags & BAM_FMUNMAP == 0 {
+                    self.both_mates_mapped += 1;
+                    // Count each fragment once, from the leftmost mate
+                    let isize = record.insert_size();
+                    if isize > 0 {
+                        *self.insert_hist.entry(isize as u64).or_insert(0) += 1;
+                    }
+                } else {
+                    self.singletons += 1;
+                }
+            }
+            self.mapq_hist[record.mapq() as usize] += 1;
+
+            let seq = record.seq();
+            let len = seq.len() as u64;
+            if len > 0 {
+                self.read_length_min = self.read_length_min.min(len);
+                self.read_length_max = self.read_length_max.max(len);
+                self.read_length_sum += len;
+                self.read_length_n += 1;
+                self.sequenced_bases += len;
+
+                let mut gc = 0u64;
+                for i in 0..seq.len() {
+                    match seq[i] {
+                        b'A' | b'a' => self.base_counts[0] += 1,
+                        b'C' | b'c' => {
+                            self.base_counts[1] += 1;
+                            gc += 1;
+                        }
+                        b'G' | b'g' => {
+                            self.base_counts[2] += 1;
+                            gc += 1;
+                        }
+                        b'T' | b't' => self.base_counts[3] += 1,
+                        _ => self.base_counts[4] += 1,
+                    }
+                }
+                let pct = (100.0 * gc as f64 / len as f64).round() as usize;
+                self.gc_hist[pct.min(100)] += 1;
+            }
+        }
+
+        if is_secondary {
+            return;
+        }
+
+        // --- coverage ---
+        let tid = record.tid();
+        if tid < 0 {
+            return;
+        }
+        if tid != self.current_tid {
+            self.flush_contig();
+            self.current_tid = tid;
+        }
+        if (tid as usize) < self.contig_reads.len() {
+            self.contig_reads[tid as usize] += 1;
+        }
+
+        let start = record.pos() as u64;
+        self.depth.advance_to(start);
+
+        let mut ref_pos = start;
+        for op in record.cigar().iter() {
+            match *op {
+                Cigar::Match(len) | Cigar::Equal(len) | Cigar::Diff(len) | Cigar::Del(len) => {
+                    let len = len as u64;
+                    self.depth.add_block(ref_pos, ref_pos + len);
+                    self.aligned_bases += len;
+                    ref_pos += len;
+                }
+                Cigar::RefSkip(len) => ref_pos += len as u64,
+                _ => {}
+            }
+        }
+    }
+
+    /// Fold the current contig's pending depth into its summary.
+    fn flush_contig(&mut self) {
+        let summary = self.depth.finish_contig();
+        if self.current_tid >= 0 && (self.current_tid as usize) < self.contig_depth.len() {
+            let idx = self.current_tid as usize;
+            let taken = summary;
+            self.contig_depth[idx].merge(&taken);
+        }
+    }
+
+    /// Finalise all pending state and produce the result.
+    pub fn into_result(mut self) -> BamqcResult {
+        self.flush_contig();
+
+        let mut global = DepthSummary::default();
+        for summary in &self.contig_depth {
+            global.merge(summary);
+        }
+
+        let reference_bases: u64 = self.contigs.iter().map(|(_, len)| len).sum();
+
+        let contigs = self
+            .contigs
+            .iter()
+            .enumerate()
+            .map(|(i, (name, len))| ContigCoverage {
+                name: name.clone(),
+                length: *len,
+                mapped_reads: self.contig_reads[i],
+                mapped_bases: self.contig_depth[i].sum_depth as u64,
+                mean_coverage: mean_coverage(&self.contig_depth[i], *len),
+                std_coverage: std_coverage(&self.contig_depth[i], *len),
+            })
+            .collect();
+
+        let mapq_sum: u128 = self
+            .mapq_hist
+            .iter()
+            .enumerate()
+            .map(|(q, &n)| q as u128 * n as u128)
+            .sum();
+        let mapq_n: u64 = self.mapq_hist.iter().sum();
+
+        let (insert_mean, insert_std, insert_median) = insert_size_stats(&self.insert_hist);
+
+        BamqcResult {
+            reference_bases,
+            num_contigs: self.contigs.len(),
+            total_reads: self.total_reads,
+            mapped_reads: self.mapped_reads,
+            unmapped_reads: self.unmapped_reads,
+            secondary: self.secondary,
+            supplementary: self.supplementary,
+            duplicates: self.duplicates,
+            qc_failed: self.qc_failed,
+            paired_reads: self.paired_reads,
+            first_in_pair: self.first_in_pair,
+            second_in_pair: self.second_in_pair,
+            both_mates_mapped: self.both_mates_mapped,
+            singletons: self.singletons,
+            read_length_min: if self.read_length_n == 0 {
+                0
+            } else {
+                self.read_length_min
+            },
+            read_length_max: self.read_length_max,
+            read_length_mean: if self.read_length_n == 0 {
+                0.0
+            } else {
+                self.read_length_sum as f64 / self.read_length_n as f64
+            },
+            sequenced_bases: self.sequenced_bases,
+            aligned_bases: self.aligned_bases,
+            base_counts: self.base_counts,
+            gc_hist: self.gc_hist,
+            mapq_mean: if mapq_n == 0 {
+                0.0
+            } else {
+                mapq_sum as f64 / mapq_n as f64
+            },
+            insert_mean,
+            insert_std,
+            insert_median,
+            insert_hist: self.insert_hist,
+            mean_coverage: mean_coverage(&global, reference_bases),
+            std_coverage: std_coverage(&global, reference_bases),
+            coverage_hist: global.hist.clone(),
+            covered_bases: global.covered,
+            contigs,
+        }
+    }
+}
+
+/// Mean depth over the whole span, counting uncovered bases as zero.
+fn mean_coverage(summary: &DepthSummary, span: u64) -> f64 {
+    if span == 0 {
+        return 0.0;
+    }
+    summary.sum_depth as f64 / span as f64
+}
+
+/// Population standard deviation of depth, counting uncovered bases as zero.
+fn std_coverage(summary: &DepthSummary, span: u64) -> f64 {
+    if span == 0 {
+        return 0.0;
+    }
+    let mean = summary.sum_depth as f64 / span as f64;
+    let mean_sq = summary.sum_sq as f64 / span as f64;
+    (mean_sq - mean * mean).max(0.0).sqrt()
+}
+
+/// Mean, population standard deviation and median of the insert size histogram.
+fn insert_size_stats(hist: &BTreeMap<u64, u64>) -> (f64, f64, u64) {
+    let total: u64 = hist.values().sum();
+    if total == 0 {
+        return (0.0, 0.0, 0);
+    }
+    let sum: u128 = hist.iter().map(|(&s, &n)| s as u128 * n as u128).sum();
+    let mean = sum as f64 / total as f64;
+    let var: f64 = hist
+        .iter()
+        .map(|(&s, &n)| {
+            let d = s as f64 - mean;
+            d * d * n as f64
+        })
+        .sum::<f64>()
+        / total as f64;
+
+    let half = total / 2;
+    let mut seen = 0u64;
+    let mut median = 0u64;
+    for (&size, &count) in hist {
+        seen += count;
+        if seen > half {
+            median = size;
+            break;
+        }
+    }
+
+    (mean, var.sqrt(), median)
+}
+
+// ===================================================================
+// Result
+// ===================================================================
+
+/// Coverage summary for one contig.
+#[derive(Debug, Clone)]
+pub struct ContigCoverage {
+    /// Contig name from the alignment header.
+    pub name: String,
+    /// Contig length in bases.
+    pub length: u64,
+    /// Primary alignments mapped to this contig.
+    pub mapped_reads: u64,
+    /// Sum of aligned reference bases on this contig.
+    pub mapped_bases: u64,
+    /// Mean depth across the contig, uncovered bases counted as zero.
+    pub mean_coverage: f64,
+    /// Population standard deviation of depth across the contig.
+    pub std_coverage: f64,
+}
+
+/// Everything the bamqc report needs.
+#[derive(Debug)]
+pub struct BamqcResult {
+    /// Total reference length across all contigs.
+    pub reference_bases: u64,
+    /// Number of contigs in the header.
+    pub num_contigs: usize,
+    /// Total alignment records.
+    pub total_reads: u64,
+    /// Records without the unmapped flag.
+    pub mapped_reads: u64,
+    /// Records with the unmapped flag.
+    pub unmapped_reads: u64,
+    /// Secondary alignments.
+    pub secondary: u64,
+    /// Supplementary alignments that are not also secondary.
+    pub supplementary: u64,
+    /// Duplicate-flagged records.
+    pub duplicates: u64,
+    /// QC-failed records.
+    pub qc_failed: u64,
+    /// Primary mapped records with the paired flag.
+    pub paired_reads: u64,
+    /// Primary mapped read-1 records.
+    pub first_in_pair: u64,
+    /// Primary mapped read-2 records.
+    pub second_in_pair: u64,
+    /// Primary mapped records whose mate is also mapped.
+    pub both_mates_mapped: u64,
+    /// Primary mapped records whose mate is unmapped.
+    pub singletons: u64,
+    /// Shortest query sequence among primary mapped reads.
+    pub read_length_min: u64,
+    /// Longest query sequence among primary mapped reads.
+    pub read_length_max: u64,
+    /// Mean query sequence length among primary mapped reads.
+    pub read_length_mean: f64,
+    /// Total query bases of primary mapped reads.
+    pub sequenced_bases: u64,
+    /// Total reference bases covered by aligned blocks.
+    pub aligned_bases: u64,
+    /// Base counts: A, C, G, T, N.
+    pub base_counts: [u64; 5],
+    /// GC percentage (whole percent) → read count.
+    pub gc_hist: [u64; 101],
+    /// Mean mapping quality of primary mapped reads.
+    pub mapq_mean: f64,
+    /// Mean insert size over fragments with positive TLEN.
+    pub insert_mean: f64,
+    /// Population standard deviation of insert size.
+    pub insert_std: f64,
+    /// Median insert size.
+    pub insert_median: u64,
+    /// abs(TLEN) → fragment count.
+    pub insert_hist: BTreeMap<u64, u64>,
+    /// Mean depth across the reference, uncovered bases counted as zero.
+    pub mean_coverage: f64,
+    /// Population standard deviation of depth across the reference.
+    pub std_coverage: f64,
+    /// depth → number of reference bases at that depth (depth ≥ 1).
+    pub coverage_hist: HashMap<u32, u64>,
+    /// Reference bases with depth ≥ 1.
+    pub covered_bases: u64,
+    /// Per-contig coverage summaries, in header order.
+    pub contigs: Vec<ContigCoverage>,
+}
+
+impl BamqcResult {
+    /// Fraction of the reference covered at depth ≥ `threshold`, as a percentage.
+    pub fn genome_fraction_at(&self, threshold: u32) -> f64 {
+        if self.reference_bases == 0 {
+            return 0.0;
+        }
+        let bases: u64 = self
+            .coverage_hist
+            .iter()
+            .filter(|(&depth, _)| depth >= threshold)
+            .map(|(_, &n)| n)
+            .sum();
+        100.0 * bases as f64 / self.reference_bases as f64
+    }
+
+    /// Overall GC percentage of sequenced bases.
+    pub fn gc_percentage(&self) -> f64 {
+        let acgt: u64 = self.base_counts[..4].iter().sum();
+        if acgt == 0 {
+            return 0.0;
+        }
+        100.0 * (self.base_counts[1] + self.base_counts[2]) as f64 / acgt as f64
+    }
+}
+
+// ===================================================================
+// Tests
+// ===================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_htslib::bam::Read as BamRead;
+
+    fn accumulate(sam: &str, contigs: Vec<(String, u64)>) -> BamqcResult {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "rustqc_bamqc_test_{:?}_{}.sam",
+            std::thread::current().id(),
+            id
+        ));
+        std::fs::write(&path, sam).unwrap();
+
+        let mut reader = bam::Reader::from_path(&path).unwrap();
+        let mut accum = BamqcAccum::new(contigs, false);
+        let mut record = bam::Record::new();
+        while let Some(res) = reader.read(&mut record) {
+            res.unwrap();
+            accum.process_read(&record);
+        }
+        let _ = std::fs::remove_file(&path);
+        accum.into_result()
+    }
+
+    #[test]
+    fn test_depth_and_genome_fraction() {
+        // Contig of 100 bases. Two 10-base reads at 1 and 6 (1-based) overlap
+        // over 5 bases, so: 5 bases at depth 2, 10 bases at depth 1.
+        let sam = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:100\n\
+r1\t0\tchr1\t1\t60\t10M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII\n\
+r2\t0\tchr1\t6\t60\t10M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII\n";
+        let result = accumulate(sam, vec![("chr1".to_string(), 100)]);
+
+        assert_eq!(result.coverage_hist.get(&1), Some(&10), "bases at depth 1");
+        assert_eq!(result.coverage_hist.get(&2), Some(&5), "bases at depth 2");
+        assert_eq!(result.covered_bases, 15);
+        assert_eq!(result.aligned_bases, 20);
+        // mean depth = 20 aligned bases / 100 reference bases
+        assert!((result.mean_coverage - 0.2).abs() < 1e-9);
+        assert!((result.genome_fraction_at(1) - 15.0).abs() < 1e-9);
+        assert!((result.genome_fraction_at(2) - 5.0).abs() < 1e-9);
+        assert!((result.genome_fraction_at(3) - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_refskip_does_not_count_as_covered() {
+        // 5M 90N 5M spans the contig but only covers 10 bases
+        let sam = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:100\n\
+r1\t0\tchr1\t1\t60\t5M90N5M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII\n";
+        let result = accumulate(sam, vec![("chr1".to_string(), 100)]);
+        assert_eq!(result.covered_bases, 10);
+        assert_eq!(result.aligned_bases, 10);
+    }
+
+    #[test]
+    fn test_per_contig_coverage_and_flags() {
+        let sam = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:100\n\
+@SQ\tSN:chr2\tLN:200\n\
+r1\t99\tchr1\t1\t60\t10M\t=\t51\t60\tGCGCGCGCGC\tIIIIIIIIII\n\
+r2\t147\tchr1\t51\t60\t10M\t=\t1\t-60\tGCGCGCGCGC\tIIIIIIIIII\n\
+r3\t256\tchr2\t1\t60\t10M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII\n\
+r4\t4\tchr2\t1\t0\t*\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII\n";
+        let result = accumulate(
+            sam,
+            vec![("chr1".to_string(), 100), ("chr2".to_string(), 200)],
+        );
+
+        assert_eq!(result.total_reads, 4);
+        assert_eq!(
+            result.mapped_reads, 3,
+            "secondary alignment counts as mapped"
+        );
+        assert_eq!(result.unmapped_reads, 1);
+        assert_eq!(result.secondary, 1);
+        assert_eq!(result.both_mates_mapped, 2);
+        assert_eq!(result.insert_median, 60, "one fragment with TLEN 60");
+
+        // Secondary alignments are excluded from coverage
+        assert_eq!(
+            result.contigs[1].mapped_bases, 0,
+            "chr2 has no primary coverage"
+        );
+        assert_eq!(result.contigs[0].mapped_bases, 20);
+        assert!((result.contigs[0].mean_coverage - 0.2).abs() < 1e-9);
+
+        // GC: two reads of GCGCGCGCGC (100%)
+        assert_eq!(result.gc_hist[100], 2);
+        assert!((result.gc_percentage() - 100.0).abs() < 1e-9);
+    }
+}

--- a/src/bamqc/mod.rs
+++ b/src/bamqc/mod.rs
@@ -1,0 +1,12 @@
+//! Generic BAM/CRAM quality control — the `bamqc` equivalent of Qualimap.
+//!
+//! Where the `rna` command reimplements Qualimap's `rnaseq` mode (read origin,
+//! transcript coverage bias, junctions — all annotation-driven), this module
+//! covers the `bamqc` mode: coverage depth and breadth, GC content, insert
+//! size, mapping quality and per-contig coverage. No GTF is required.
+
+pub mod accumulator;
+pub mod output;
+
+pub use accumulator::{BamqcAccum, BamqcResult, ContigCoverage};
+pub use output::write_all;

--- a/src/bamqc/output.rs
+++ b/src/bamqc/output.rs
@@ -1,0 +1,350 @@
+//! Qualimap `bamqc`-compatible output files.
+//!
+//! Writes `genome_results.txt` plus the `raw_data_qualimapReport/` tables that
+//! MultiQC's Qualimap BamQC module parses.
+
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use log::debug;
+
+use super::accumulator::{BamqcResult, COVERAGE_THRESHOLDS};
+
+/// Write all bamqc output files under `outdir`.
+///
+/// Produces:
+/// - `genome_results.txt`
+/// - `raw_data_qualimapReport/coverage_histogram.txt`
+/// - `raw_data_qualimapReport/genome_fraction_coverage.txt`
+/// - `raw_data_qualimapReport/mapped_reads_gc-content_distribution.txt`
+/// - `raw_data_qualimapReport/mapped_reads_nucleotide_content.txt`
+/// - `raw_data_qualimapReport/insert_size_histogram.txt`
+///
+/// # Arguments
+/// * `result` - The accumulated metrics
+/// * `sample_name` - Sample name recorded in the report
+/// * `bam_path` - Input path recorded in the report
+/// * `outdir` - Directory to write into
+///
+/// # Returns
+/// The paths written, in the order listed above
+pub fn write_all(
+    result: &BamqcResult,
+    sample_name: &str,
+    bam_path: &str,
+    outdir: &Path,
+) -> Result<Vec<std::path::PathBuf>> {
+    std::fs::create_dir_all(outdir)
+        .with_context(|| format!("Failed to create output directory: {}", outdir.display()))?;
+    let raw_dir = outdir.join("raw_data_qualimapReport");
+    std::fs::create_dir_all(&raw_dir)
+        .with_context(|| format!("Failed to create directory: {}", raw_dir.display()))?;
+
+    let mut written = Vec::new();
+
+    let genome_results = outdir.join("genome_results.txt");
+    write_genome_results(result, sample_name, bam_path, &genome_results)?;
+    written.push(genome_results);
+
+    let cov_hist = raw_dir.join("coverage_histogram.txt");
+    write_coverage_histogram(result, &cov_hist)?;
+    written.push(cov_hist);
+
+    let genome_fraction = raw_dir.join("genome_fraction_coverage.txt");
+    write_genome_fraction(result, &genome_fraction)?;
+    written.push(genome_fraction);
+
+    let gc = raw_dir.join("mapped_reads_gc-content_distribution.txt");
+    write_gc_distribution(result, &gc)?;
+    written.push(gc);
+
+    let nucleotide = raw_dir.join("mapped_reads_nucleotide_content.txt");
+    write_nucleotide_content(result, &nucleotide)?;
+    written.push(nucleotide);
+
+    let insert = raw_dir.join("insert_size_histogram.txt");
+    write_insert_size_histogram(result, &insert)?;
+    written.push(insert);
+
+    debug!("Wrote bamqc outputs to {}", outdir.display());
+    Ok(written)
+}
+
+/// Format a count with Qualimap's thousands separators (e.g. `1,234,567`).
+fn commas(value: u64) -> String {
+    let digits = value.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, ch) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Percentage of `part` in `whole`, guarding against a zero denominator.
+fn pct(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        100.0 * part as f64 / whole as f64
+    }
+}
+
+/// Write the main `genome_results.txt` summary.
+fn write_genome_results(
+    result: &BamqcResult,
+    sample_name: &str,
+    bam_path: &str,
+    path: &Path,
+) -> Result<()> {
+    let mut out = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create {}", path.display()))?;
+
+    writeln!(out, "BamQC report")?;
+    writeln!(out, "-----------------------------------")?;
+    writeln!(out)?;
+    writeln!(out, ">>>>>>> Input")?;
+    writeln!(out)?;
+    writeln!(out, "     bam file = {bam_path}")?;
+    writeln!(out, "     outfile = genome_results.txt")?;
+    writeln!(out, "     sample = {sample_name}")?;
+    writeln!(out)?;
+    writeln!(out, ">>>>>>> Reference")?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "     number of bases = {} bp",
+        commas(result.reference_bases)
+    )?;
+    writeln!(out, "     number of contigs = {}", result.num_contigs)?;
+    writeln!(out)?;
+    writeln!(out, ">>>>>>> Globals")?;
+    writeln!(out)?;
+    writeln!(out, "     number of reads = {}", commas(result.total_reads))?;
+    writeln!(
+        out,
+        "     number of mapped reads = {} ({:.2}%)",
+        commas(result.mapped_reads),
+        pct(result.mapped_reads, result.total_reads)
+    )?;
+    writeln!(
+        out,
+        "     number of secondary alignments = {}",
+        commas(result.secondary)
+    )?;
+    writeln!(
+        out,
+        "     number of supplementary alignments = {}",
+        commas(result.supplementary)
+    )?;
+    writeln!(
+        out,
+        "     number of mapped paired reads (first in pair) = {}",
+        commas(result.first_in_pair)
+    )?;
+    writeln!(
+        out,
+        "     number of mapped paired reads (second in pair) = {}",
+        commas(result.second_in_pair)
+    )?;
+    writeln!(
+        out,
+        "     number of mapped paired reads (both in pair) = {}",
+        commas(result.both_mates_mapped)
+    )?;
+    writeln!(
+        out,
+        "     number of mapped paired reads (singletons) = {}",
+        commas(result.singletons)
+    )?;
+    writeln!(
+        out,
+        "     number of duplicated reads (flagged) = {}",
+        commas(result.duplicates)
+    )?;
+    writeln!(
+        out,
+        "     number of QC-failed reads = {}",
+        commas(result.qc_failed)
+    )?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "     number of mapped bases = {} bp",
+        commas(result.aligned_bases)
+    )?;
+    writeln!(
+        out,
+        "     number of sequenced bases = {} bp",
+        commas(result.sequenced_bases)
+    )?;
+    writeln!(out)?;
+    writeln!(out, "     read min length = {}", result.read_length_min)?;
+    writeln!(out, "     read max length = {}", result.read_length_max)?;
+    writeln!(
+        out,
+        "     read mean length = {:.2}",
+        result.read_length_mean
+    )?;
+    writeln!(out)?;
+    writeln!(out, ">>>>>>> Insert size")?;
+    writeln!(out)?;
+    writeln!(out, "     mean insert size = {:.4}", result.insert_mean)?;
+    writeln!(out, "     std insert size = {:.4}", result.insert_std)?;
+    writeln!(out, "     median insert size = {}", result.insert_median)?;
+    writeln!(out)?;
+    writeln!(out, ">>>>>>> Mapping quality")?;
+    writeln!(out)?;
+    writeln!(out, "     mean mapping quality = {:.4}", result.mapq_mean)?;
+    writeln!(out)?;
+    writeln!(out, ">>>>>>> ACTG content")?;
+    writeln!(out)?;
+    let acgt: u64 = result.base_counts[..4].iter().sum();
+    let labels = ["A", "C", "G", "T", "N"];
+    for (i, label) in labels.iter().enumerate() {
+        if i < 4 {
+            writeln!(
+                out,
+                "     number of {}'s = {} bp ({:.2}%)",
+                label,
+                commas(result.base_counts[i]),
+                pct(result.base_counts[i], acgt)
+            )?;
+        } else {
+            writeln!(
+                out,
+                "     number of {}'s = {} bp",
+                label,
+                commas(result.base_counts[i])
+            )?;
+        }
+    }
+    writeln!(out, "     GC percentage = {:.2}%", result.gc_percentage())?;
+    writeln!(out)?;
+    writeln!(out, ">>>>>>> Coverage")?;
+    writeln!(out)?;
+    writeln!(out, "     mean coverageData = {:.4}X", result.mean_coverage)?;
+    writeln!(out, "     std coverageData = {:.4}X", result.std_coverage)?;
+    writeln!(out)?;
+    for threshold in COVERAGE_THRESHOLDS {
+        writeln!(
+            out,
+            "     There is a {:.2}% of reference with a coverageData >= {}X",
+            result.genome_fraction_at(threshold),
+            threshold
+        )?;
+    }
+    writeln!(out)?;
+    writeln!(out, ">>>>>>> Coverage per contig")?;
+    writeln!(out)?;
+    for contig in &result.contigs {
+        writeln!(
+            out,
+            "\t{}\t{}\t{}\t{:.10}\t{:.10}",
+            contig.name,
+            contig.length,
+            contig.mapped_bases,
+            contig.mean_coverage,
+            contig.std_coverage
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Write the depth histogram (`coverage_histogram.txt`).
+fn write_coverage_histogram(result: &BamqcResult, path: &Path) -> Result<()> {
+    let mut out = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create {}", path.display()))?;
+    writeln!(out, "#Coverage\tNumber of genomic locations")?;
+
+    let mut depths: Vec<(&u32, &u64)> = result.coverage_hist.iter().collect();
+    depths.sort_unstable();
+    for (&depth, &count) in depths {
+        writeln!(out, "{}.0\t{}.0", depth, count)?;
+    }
+    Ok(())
+}
+
+/// Write the cumulative genome fraction curve (`genome_fraction_coverage.txt`).
+fn write_genome_fraction(result: &BamqcResult, path: &Path) -> Result<()> {
+    let mut out = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create {}", path.display()))?;
+    writeln!(out, "#Coverage (X)\tPercentage of reference (%)")?;
+
+    let max_depth = result.coverage_hist.keys().copied().max().unwrap_or(0);
+    // Cap the reported curve the way Qualimap does, so a handful of very deep
+    // positions cannot produce a multi-million-row file.
+    let limit = max_depth.min(1000);
+    for depth in 1..=limit.max(1) {
+        writeln!(out, "{}.0\t{:.10}", depth, result.genome_fraction_at(depth))?;
+    }
+    Ok(())
+}
+
+/// Write the read GC distribution (`mapped_reads_gc-content_distribution.txt`).
+fn write_gc_distribution(result: &BamqcResult, path: &Path) -> Result<()> {
+    let mut out = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create {}", path.display()))?;
+    writeln!(out, "#GC Content (%)\tSample")?;
+
+    let total: u64 = result.gc_hist.iter().sum();
+    for (pct_bin, &count) in result.gc_hist.iter().enumerate() {
+        let fraction = if total == 0 {
+            0.0
+        } else {
+            count as f64 / total as f64
+        };
+        writeln!(out, "{}.0\t{:.10}", pct_bin, fraction)?;
+    }
+    Ok(())
+}
+
+/// Write the overall base composition (`mapped_reads_nucleotide_content.txt`).
+fn write_nucleotide_content(result: &BamqcResult, path: &Path) -> Result<()> {
+    let mut out = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create {}", path.display()))?;
+    writeln!(out, "#Base\tCount\tFraction")?;
+
+    let total: u64 = result.base_counts.iter().sum();
+    for (label, &count) in ["A", "C", "G", "T", "N"].iter().zip(&result.base_counts) {
+        let fraction = if total == 0 {
+            0.0
+        } else {
+            count as f64 / total as f64
+        };
+        writeln!(out, "{label}\t{count}\t{fraction:.10}")?;
+    }
+    Ok(())
+}
+
+/// Write the insert size histogram (`insert_size_histogram.txt`).
+fn write_insert_size_histogram(result: &BamqcResult, path: &Path) -> Result<()> {
+    let mut out = std::fs::File::create(path)
+        .with_context(|| format!("Failed to create {}", path.display()))?;
+    writeln!(out, "#Insert size\tNumber of reads")?;
+    for (&size, &count) in &result.insert_hist {
+        writeln!(out, "{}.0\t{}.0", size, count)?;
+    }
+    Ok(())
+}
+
+// ===================================================================
+// Tests
+// ===================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_commas() {
+        assert_eq!(commas(0), "0");
+        assert_eq!(commas(999), "999");
+        assert_eq!(commas(1000), "1,000");
+        assert_eq!(commas(1234567), "1,234,567");
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,99 @@ pub enum Commands {
     /// analyses in one pass. Requires a GTF annotation and duplicate-marked
     /// (not removed) alignments.
     Rna(RnaArgs),
+
+    /// Generic BAM/CRAM QC — coverage, GC, insert size, mapping quality.
+    ///
+    /// The `bamqc` equivalent of Qualimap: genomic QC that needs no
+    /// annotation. Use `rustqc rna` for RNA-seq specific analyses.
+    Bamqc(BamqcArgs),
+}
+
+/// Arguments for the `bamqc` subcommand.
+#[derive(Parser, Debug)]
+#[command(
+    next_line_help = false,
+    term_width = 120,
+    help_template = "\
+{about-with-newline}
+{usage-heading} {usage}
+
+{all-args}"
+)]
+pub struct BamqcArgs {
+    /// Coordinate-sorted alignment file (BAM/SAM/CRAM)
+    #[arg(value_name = "INPUT", required = true, help_heading = "Input / Output")]
+    pub input: String,
+
+    /// Reference FASTA (required for CRAM)
+    #[arg(
+        short,
+        long,
+        value_name = "FASTA",
+        env = "RUSTQC_REFERENCE",
+        help_heading = "Input / Output"
+    )]
+    pub reference: Option<String>,
+
+    /// Output directory [default: .]
+    #[arg(
+        short,
+        long,
+        default_value = ".",
+        hide_default_value = true,
+        env = "RUSTQC_OUTDIR",
+        help_heading = "Input / Output"
+    )]
+    pub outdir: String,
+
+    /// Override sample name (default: derived from the input filename)
+    #[arg(
+        long,
+        value_name = "NAME",
+        env = "RUSTQC_SAMPLE_NAME",
+        help_heading = "Input / Output"
+    )]
+    pub sample_name: Option<String>,
+
+    /// Number of htslib decompression threads [default: 1]
+    #[arg(
+        short,
+        long,
+        default_value_t = 1,
+        hide_default_value = true,
+        env = "RUSTQC_THREADS",
+        help_heading = "General"
+    )]
+    pub threads: usize,
+
+    /// Exclude duplicate-flagged reads from all metrics (Qualimap --skip-duplicated)
+    #[arg(
+        long,
+        default_value_t = false,
+        env = "RUSTQC_SKIP_DUPLICATED",
+        help_heading = "General"
+    )]
+    pub skip_duplicated: bool,
+
+    /// Suppress output except warnings/errors
+    #[arg(
+        short = 'q',
+        long,
+        conflicts_with = "verbose",
+        env = "RUSTQC_QUIET",
+        help_heading = "General"
+    )]
+    pub quiet: bool,
+
+    /// Show additional detail
+    #[arg(
+        short = 'v',
+        long,
+        conflicts_with = "quiet",
+        env = "RUSTQC_VERBOSE",
+        help_heading = "General"
+    )]
+    pub verbose: bool,
 }
 
 /// Arguments for the `rna` subcommand.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@
 use clap::ValueEnum;
 use serde::Deserialize;
 
+pub mod bamqc;
 pub mod config;
 pub mod cpu;
 pub mod gtf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,8 @@ fn main() -> Result<()> {
     let verbosity = match &cli.command {
         cli::Commands::Rna(args) if args.quiet => Verbosity::Quiet,
         cli::Commands::Rna(args) if args.verbose => Verbosity::Verbose,
+        cli::Commands::Bamqc(args) if args.quiet => Verbosity::Quiet,
+        cli::Commands::Bamqc(args) if args.verbose => Verbosity::Verbose,
         _ => Verbosity::Normal,
     };
 
@@ -94,7 +96,86 @@ fn main() -> Result<()> {
 
     match cli.command {
         cli::Commands::Rna(args) => run_rna(args, &ui),
+        cli::Commands::Bamqc(args) => run_bamqc(args, &ui),
     }
+}
+
+/// Run the `bamqc` subcommand: generic BAM/CRAM QC in a single streaming pass.
+///
+/// # Arguments
+/// * `args` - Parsed CLI arguments
+/// * `ui` - Terminal UI handle
+fn run_bamqc(args: cli::BamqcArgs, ui: &Ui) -> Result<()> {
+    use rustqc::bamqc;
+
+    let start = Instant::now();
+    let sample_name = args.sample_name.clone().unwrap_or_else(|| {
+        Path::new(&args.input)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("sample")
+            .to_string()
+    });
+
+    ui.blank();
+    ui.step(&format!("Processing {}", args.input));
+
+    let mut reader = rust_htslib::bam::Reader::from_path(&args.input)
+        .with_context(|| format!("Failed to open alignment file: {}", args.input))?;
+    if let Some(ref_path) = args.reference.as_deref() {
+        reader
+            .set_reference(ref_path)
+            .with_context(|| format!("Failed to set reference FASTA: {}", ref_path))?;
+    }
+    if args.threads > 1 {
+        reader
+            .set_threads(args.threads.saturating_sub(1))
+            .context("Failed to set htslib decompression threads")?;
+    }
+
+    let header = reader.header().clone();
+    let contigs: Vec<(String, u64)> = (0..header.target_count())
+        .map(|tid| {
+            (
+                String::from_utf8_lossy(header.tid2name(tid)).to_string(),
+                header.target_len(tid).unwrap_or(0),
+            )
+        })
+        .collect();
+    ensure!(
+        !contigs.is_empty(),
+        "Alignment file has no reference sequences in its header: {}",
+        args.input
+    );
+
+    let mut accum = bamqc::BamqcAccum::new(contigs, args.skip_duplicated);
+    let mut record = rust_htslib::bam::Record::new();
+    let mut n = 0u64;
+    while let Some(res) = reader.read(&mut record) {
+        res.context("Error reading alignment record")?;
+        accum.process_read(&record);
+        n += 1;
+    }
+    let result = accum.into_result();
+
+    ui.detail(&format!(
+        "{} records, mean coverage {:.2}X, {:.2}% of reference covered",
+        format_count(n),
+        result.mean_coverage,
+        result.genome_fraction_at(1),
+    ));
+
+    let outdir = Path::new(&args.outdir);
+    let written = bamqc::write_all(&result, &sample_name, &args.input, outdir)?;
+
+    ui.output_group("bamqc");
+    for path in &written {
+        ui.output_item("bamqc", &path.display().to_string());
+    }
+
+    ui.blank();
+    ui.detail(&format!("Finished in {}", format_duration(start.elapsed())));
+    Ok(())
 }
 
 /// Reconstruct the command line for the featureCounts-compatible header comment.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1026,3 +1026,118 @@ fn test_dup_check_parallel_uses_global_duplicate_state() {
 
     let _ = fs::remove_dir_all(root);
 }
+
+// ============================================================================
+// bamqc subcommand (Qualimap bamqc mode)
+// ============================================================================
+
+/// Run `rustqc bamqc` on the test BAM.
+fn run_bamqc(outdir: &str, extra: &[&str]) -> std::process::Output {
+    let binary = rustqc_binary();
+    let mut args = vec!["bamqc", "tests/data/test.bam", "--outdir", outdir];
+    args.extend_from_slice(extra);
+    Command::new(&binary)
+        .args(&args)
+        .output()
+        .expect("Failed to run rustqc bamqc")
+}
+
+/// Extract a `key = value` line from genome_results.txt.
+fn genome_results_value(contents: &str, key: &str) -> String {
+    contents
+        .lines()
+        .find(|l| l.trim_start().starts_with(key))
+        .unwrap_or_else(|| panic!("missing '{key}' in genome_results.txt"))
+        .split('=')
+        .nth(1)
+        .unwrap()
+        .trim()
+        .to_string()
+}
+
+#[test]
+fn test_bamqc_outputs_and_coverage_match_samtools() {
+    let root = unique_test_dir("bamqc");
+    let outdir = root.display().to_string();
+    let output = run_bamqc(&outdir, &[]);
+    assert!(
+        output.status.success(),
+        "rustqc bamqc failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    for file in [
+        "genome_results.txt",
+        "raw_data_qualimapReport/coverage_histogram.txt",
+        "raw_data_qualimapReport/genome_fraction_coverage.txt",
+        "raw_data_qualimapReport/mapped_reads_gc-content_distribution.txt",
+        "raw_data_qualimapReport/mapped_reads_nucleotide_content.txt",
+        "raw_data_qualimapReport/insert_size_histogram.txt",
+    ] {
+        assert!(
+            Path::new(&format!("{outdir}/{file}")).exists(),
+            "missing bamqc output: {file}"
+        );
+    }
+
+    let contents = fs::read_to_string(format!("{outdir}/genome_results.txt")).unwrap();
+
+    // Reference: two 20 kb contigs
+    assert_eq!(
+        genome_results_value(&contents, "number of bases"),
+        "40,000 bp"
+    );
+    assert_eq!(genome_results_value(&contents, "number of contigs"), "2");
+
+    // Reads: 488 records, 483 mapped
+    assert_eq!(genome_results_value(&contents, "number of reads"), "488");
+    assert!(
+        genome_results_value(&contents, "number of mapped reads").starts_with("483"),
+        "unexpected mapped read count"
+    );
+
+    // Coverage, cross-checked against
+    //   samtools depth -a -J -g DUP tests/data/test.bam
+    // (duplicates included, matching Qualimap's default)
+    assert_eq!(
+        genome_results_value(&contents, "mean coverageData"),
+        "0.6038X"
+    );
+    assert!(
+        contents.contains("There is a 12.16% of reference with a coverageData >= 1X"),
+        "genome fraction at 1X must match samtools depth"
+    );
+    assert!(
+        contents.contains("There is a 4.78% of reference with a coverageData >= 5X"),
+        "genome fraction at 5X must match samtools depth"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn test_bamqc_skip_duplicated_matches_samtools_default() {
+    let root = unique_test_dir("bamqc-nodup");
+    let outdir = root.display().to_string();
+    let output = run_bamqc(&outdir, &["--skip-duplicated"]);
+    assert!(
+        output.status.success(),
+        "rustqc bamqc failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let contents = fs::read_to_string(format!("{outdir}/genome_results.txt")).unwrap();
+
+    // Cross-checked against `samtools depth -a -J tests/data/test.bam`, whose
+    // default filter excludes duplicates
+    assert_eq!(
+        genome_results_value(&contents, "mean coverageData"),
+        "0.4325X"
+    );
+    assert!(
+        contents.contains("There is a 11.55% of reference with a coverageData >= 1X"),
+        "genome fraction at 1X must match samtools depth"
+    );
+
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Closes #128.

Adds `rustqc bamqc` — generic genomic QC in one streaming pass, no GTF required:

```bash
rustqc bamqc sample.bam --outdir results/
rustqc bamqc sample.cram --reference genome.fa --outdir results/
```

## What it reports

Coverage depth and breadth (genome-wide and per contig), GC content, insert size, mapping quality, read lengths and base composition — the metrics side of Qualimap's `bamqc` mode.

Output names and layout match Qualimap, so MultiQC's Qualimap BamQC module picks them up unchanged:

```
genome_results.txt
raw_data_qualimapReport/coverage_histogram.txt
raw_data_qualimapReport/genome_fraction_coverage.txt
raw_data_qualimapReport/mapped_reads_gc-content_distribution.txt
raw_data_qualimapReport/mapped_reads_nucleotide_content.txt
raw_data_qualimapReport/insert_size_histogram.txt
```

## Coverage is exact, not sampled

Each read contributes `+1` over every aligned block (`M`/`=`/`X`/`D`); `N` skips leave a gap. Since input is coordinate-sorted, depth is finalised as the file streams past, so memory scales with pile-up depth rather than genome size — no per-base array.

Secondary alignments are excluded from coverage. Duplicates are **included** by default (Qualimap's default); `--skip-duplicated` excludes them.

## Validation

Cross-checked against `samtools depth` on `tests/data/test.bam`, both modes, and pinned in integration tests:

| Mode | RustQC | samtools |
|---|---|---|
| default | mean 0.6038X, 12.16% ≥ 1X, 4.78% ≥ 5X | `samtools depth -a -J -g DUP` → identical |
| `--skip-duplicated` | mean 0.4325X, 11.55% ≥ 1X | `samtools depth -a -J` → identical |

(The two differ by exactly the 137 duplicate-flagged reads × 50 bp in the test file.)

## Scope

This is the metrics subset, not all of Qualimap `bamqc`. Not included: the HTML report, per-window coverage tracks, clipping profile, homopolymer indel breakdown, PCR-bias/chimerism estimates, and coverage restricted to a target BED (`--feature-file`). The docs page states this explicitly. Happy to extend if you'd like any of those in the first cut — and the offer in the issue to validate against real Qualimap output on real data would be well worth taking up, since my validation here is against `samtools depth` rather than Qualimap itself.

Note this overlaps in machinery with #18 (single-pass CRAM QC): the depth tracker here is what a mosdepth-equivalent would build on.

- `cargo test` — 204 lib + 20 integration tests pass
- `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- New docs page `docs/bamqc`, AGENTS.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)