### PR TITLE
perf: use mimalloc as the global allocator in the binary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,7 @@ To prepare a release:
 | `rayon`                | Data parallelism                      |
 | `rand` / `rand_chacha` | Reproducible random sampling          |
 | `flate2`               | Gzip decompression (annotation files) |
+| `mimalloc`             | Global allocator for the binary (default feature `mimalloc`, binary only) |
 
 ## Duplicate Marking Validation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1091,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1491,6 +1509,7 @@ dependencies = [
  "indexmap",
  "indicatif",
  "log",
+ "mimalloc",
  "number_prefix",
  "plotters",
  "plotters-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,17 @@ path = "src/lib.rs"
 name = "rustqc"
 path = "src/main.rs"
 
+[features]
+default = ["mimalloc"]
+# Use mimalloc as the global allocator in the `rustqc` binary. Enabled by
+# default; disable with `--no-default-features` to fall back to the system
+# allocator (e.g. when profiling with an external heap profiler).
+mimalloc = ["dep:mimalloc"]
+
 [dependencies]
+# Allocator for the binary (see the `#[global_allocator]` in src/main.rs)
+mimalloc = { version = "0.1", optional = true }
+
 # CLI argument parsing
 clap = { version = "4", features = ["derive", "env"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,20 @@ mod citations;
 mod cli;
 mod ui;
 
+/// Global allocator for the `rustqc` binary.
+///
+/// The pipeline is allocation-heavy (per-read buffers, mate-pair maps, growing
+/// per-chromosome vectors) and runs those allocations from several rayon worker
+/// threads at once, which makes it sensitive to allocator contention. mimalloc's
+/// per-thread free lists avoid that contention.
+///
+/// This is deliberately declared in the binary and not in `lib.rs`: a
+/// `#[global_allocator]` is process-wide, so a library must not impose one on
+/// its dependents. Library users who want mimalloc can declare it themselves.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use anyhow::{ensure, Context, Result};
 use indexmap::IndexMap;
 use log::debug;


### PR DESCRIPTION
## What

Uses [mimalloc](https://github.com/microsoft/mimalloc) as the `#[global_allocator]` for the `rustqc` binary, behind a default-on `mimalloc` feature.

## Why

The single-pass pipeline allocates constantly (per-read buffers, the mate-pair `HashMap`, per-chromosome vectors that grow during counting) and does so from several rayon workers at once. That pattern is dominated by allocator lock contention under the system allocator.

## Measurement

Synthetic dataset (a real one would be better, happy to re-run against the RustQC-benchmarks pipeline):

- BAM: 4,000,000 reads, coordinate-sorted, 24 contigs (~40-58 Mb each), 15% duplicate-flagged, 25% spliced
- GTF: 1,212,002 lines / 60,000 genes / 150,000 transcripts
- aarch64 macOS, `--threads 4`, `hyperfine -w 1 -r 5`

| | wall clock | user CPU |
|---|---|---|
| `main` | 22.122 s ± 0.197 s | 22.567 s |
| this PR | 20.540 s ± 0.223 s | 19.105 s |

**1.08 ± 0.02x faster**, and user CPU time drops 15%. The gap should widen with higher `--threads` since the win is contention-related.

Confirmed on a second dataset (same size but with random read sequences, so the dedup maps are fully populated), 5 interleaved runs, medians:

| | real | user |
|---|---|---|
| `main` | 24.43 s | 25.76 s |
| this PR | 23.10 s | 21.57 s |

Same shape: 1.06x wall clock, user CPU down 16%.

## Parity

All data outputs are byte-identical before/after: `featureCounts.tsv`, `tin.xls`, `lc_extrap.txt`, samtools `stats`/`flagstat`/`idxstats`, Qualimap, and all RSeQC outputs. `cargo test --release` passes (200 + 12 + 18 + 2).

## Notes / trade-offs

- Declared in `src/main.rs`, **not** `src/lib.rs`. `#[global_allocator]` is process-wide, so a library must not impose one on its dependents. Library users who want it can declare it themselves.
- `--no-default-features` restores the system allocator, which is what you want when profiling with an external heap profiler.
- mimalloc builds C via `cc`, so no new system requirement beyond the toolchain `rust-htslib` already needs. It cross-compiles to all 8 release targets (linux gnu / darwin, x86_64 / aarch64).
- Binary size grows by roughly 100 KB.

## Unrelated observation

While diffing outputs I noticed `dupradar/*_duprateExpDens.{svg,png}` is **not** reproducible run-to-run on `main` alone: the same points are emitted in a different order between two runs of the same binary on the same input. Data outputs are all stable; it looks like plot points are iterated straight out of a `HashMap`. Happy to open a separate issue.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #143.
