### PR TITLE
perf: switch flate2 to the zlib-rs backend (2.3x faster gzip)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,7 +254,7 @@ To prepare a release:
 | `coitrees`             | Cache-oblivious interval trees        |
 | `rayon`                | Data parallelism                      |
 | `rand` / `rand_chacha` | Reproducible random sampling          |
-| `flate2`               | Gzip decompression (annotation files) |
+| `flate2`               | Gzip decompression (annotation files, `zlib-rs` backend) |
 
 ## Duplicate Marking Validation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2289,6 +2290,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,10 @@ rayon = "1.11"
 rand = "0.10"
 rand_chacha = "0.10"
 
-# Gzip decompression for .gz annotation files
-flate2 = "1"
+# Gzip decompression for .gz annotation files.
+# zlib-rs is a pure-Rust zlib rewrite: ~2.3x faster than flate2's default
+# miniz_oxide backend on GTF data, with no C toolchain requirement.
+flate2 = { version = "1.1", default-features = false, features = ["zlib-rs"] }
 
 # General utilities
 anyhow = "1"


### PR DESCRIPTION
## What

Switches `flate2` from its default `miniz_oxide` backend to [`zlib-rs`](https://github.com/trifectatechfoundation/zlib-rs), a pure-Rust rewrite of zlib. Dependency change only, no source changes.

## Measurement

Decompressing `Homo_sapiens.GRCh38.113.gtf.gz` (61 MB compressed, 1.74 GB / 4,114,455 lines uncompressed) through `io::open_reader()`, aarch64 macOS, `hyperfine -w 1 -r 5`:

| backend | time | vs current |
|---|---|---|
| `miniz_oxide` (current default) | 777.4 ms ± 7.8 ms | — |
| `zlib-ng` (C) | 441.4 ms ± 2.4 ms | 1.76x |
| **`zlib-rs` (this PR)** | **334.9 ms ± 1.4 ms** | **2.32x** |

End to end, `parse_gtf()` on that gzipped GTF: 2.997 s ± 0.015 s → 2.820 s ± 0.024 s. The gzip path is a fixed cost on every run that uses a `.gz` annotation, which is the common case for Ensembl/GENCODE downloads.

## Why zlib-rs and not zlib-ng

I benchmarked both. zlib-ng is the more commonly cited option but it is C: it needs cmake at build time and adds a native artifact to all 8 release targets and the Docker images. zlib-rs is faster here *and* pure Rust, so nothing changes for cross-compilation or the release matrix.

`libz-ng-sys` would also have been safe symbol-wise (it builds in non-compat `zng_` mode, so no clash with the zlib that `rust-htslib` links), but there was no reason to take the C dependency once zlib-rs measured faster.

## Notes

- `rust-htslib` keeps using its own zlib for BGZF. This only affects the annotation-file reader in `src/io.rs`.
- Bumped the `flate2` requirement to `1.1` since that is where the `zlib-rs` backend landed. MSRV is unaffected (project is on 1.87).
- `cargo test --release` passes (200 + 12 + 18 + 2). Parsing the same annotation plain vs gzipped gives identical results (78,932 genes / 387,944 transcripts / 2,164,410 exons).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #143.
