### PR TITLE
perf: buffer all output file writers (2.4x wall clock)

### DIFF
--- a/src/rna/dupradar/plots.rs
+++ b/src/rna/dupradar/plots.rs
@@ -1288,13 +1288,15 @@ pub fn write_intercept_slope(
     path: &std::path::Path,
 ) -> Result<()> {
     use std::io::Write;
-    let mut f = std::fs::File::create(path)?;
+    let f = std::fs::File::create(path)?;
+    let mut f = std::io::BufWriter::new(f);
     write!(
         f,
         "{sample_name} - dupRadar Int (duprate at low read counts): {}\n\
          {sample_name} - dupRadar Sl (progression of the duplication rate): {}\n",
         fit.intercept, fit.slope
     )?;
+    f.flush()?;
     Ok(())
 }
 
@@ -1305,7 +1307,8 @@ pub fn write_mqc_intercept(
     path: &std::path::Path,
 ) -> Result<()> {
     use std::io::Write;
-    let mut f = std::fs::File::create(path)?;
+    let f = std::fs::File::create(path)?;
+    let mut f = std::io::BufWriter::new(f);
     writeln!(f, "# id: dupRadar")?;
     writeln!(f, "# plot_type: 'generalstats'")?;
     writeln!(f, "# pconfig:")?;
@@ -1321,13 +1324,15 @@ pub fn write_mqc_intercept(
     writeln!(f, "#         format: '{{:.2f}}'")?;
     writeln!(f, "Sample\tdupRadar_intercept")?;
     writeln!(f, "{}\t{}", sample_name, fit.intercept)?;
+    f.flush()?;
     Ok(())
 }
 
 /// Write a MultiQC-compatible line-graph curve file.
 pub fn write_mqc_curve(fit: &FitResult, dm: &DupMatrix, path: &std::path::Path) -> Result<()> {
     use std::io::Write;
-    let mut f = std::fs::File::create(path)?;
+    let f = std::fs::File::create(path)?;
+    let mut f = std::io::BufWriter::new(f);
     writeln!(f, "# id: 'dupradar'")?;
     writeln!(f, "# section_name: 'dupRadar'")?;
     writeln!(f, "# description: 'Duplication rate vs expression'")?;
@@ -1362,6 +1367,7 @@ pub fn write_mqc_curve(fit: &FitResult, dm: &DupMatrix, path: &std::path::Path) 
         let pct = fit.predict_rpk(rpk) * 100.0;
         writeln!(f, "{}\t{}", rpk, pct)?;
     }
+    f.flush()?;
     Ok(())
 }
 

--- a/src/rna/preseq.rs
+++ b/src/rna/preseq.rs
@@ -1258,8 +1258,9 @@ pub fn write_output(
     output_path: &Path,
     confidence_level: f64,
 ) -> Result<()> {
-    let mut f = std::fs::File::create(output_path)
+    let f = std::fs::File::create(output_path)
         .with_context(|| format!("Failed to create preseq output: {}", output_path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     // Write header
     writeln!(
@@ -1285,6 +1286,7 @@ pub fn write_output(
     }
 
     debug!("Wrote preseq output to {}", output_path.display());
+    f.flush()?;
     Ok(())
 }
 

--- a/src/rna/qualimap/output.rs
+++ b/src/rna/qualimap/output.rs
@@ -307,8 +307,9 @@ fn compute_mean_coverage_histogram(
 fn write_coverage_profile(profile: &[f64; NUM_BINS], path: &Path) -> Result<()> {
     use std::fs::File;
 
-    let mut f = File::create(path)
+    let f = File::create(path)
         .with_context(|| format!("Failed to create coverage profile: {}", path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     writeln!(f, "#Transcript position\tTranscript coverage profile")?;
 
@@ -316,6 +317,7 @@ fn write_coverage_profile(profile: &[f64; NUM_BINS], path: &Path) -> Result<()> 
         writeln!(f, "{:.1}\t{}", i as f64, val)?;
     }
 
+    f.flush()?;
     Ok(())
 }
 
@@ -586,8 +588,8 @@ fn write_results_file(
 ) -> Result<()> {
     use std::fs::File;
 
-    let mut f =
-        File::create(path).with_context(|| format!("Failed to create {}", path.display()))?;
+    let f = File::create(path).with_context(|| format!("Failed to create {}", path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     // Header
     writeln!(f, "RNA-Seq QC report")?;
@@ -764,6 +766,7 @@ fn write_results_file(
         }
     }
 
+    f.flush()?;
     Ok(())
 }
 

--- a/src/rna/qualimap/report.rs
+++ b/src/rna/qualimap/report.rs
@@ -167,12 +167,14 @@ pub fn write_html_report(data: &ReportData, output_dir: &Path) -> Result<()> {
 
     let html = render_report(data)?;
 
-    let mut f = std::fs::File::create(&path)
+    let f = std::fs::File::create(&path)
         .with_context(|| format!("Failed to create {}", path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
     f.write_all(html.as_bytes())
         .with_context(|| format!("Failed to write {}", path.display()))?;
 
     debug!("Wrote HTML report: {}", path.display());
+    f.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/bam_stat.rs
+++ b/src/rna/rseqc/bam_stat.rs
@@ -277,8 +277,9 @@ impl Default for BamStatResult {
 /// * `result` - The computed statistics
 /// * `output_path` - Path to write the output file
 pub fn write_bam_stat(result: &BamStatResult, output_path: &Path) -> Result<()> {
-    let mut out = std::fs::File::create(output_path)
+    let out = std::fs::File::create(output_path)
         .with_context(|| format!("Failed to create output file: {}", output_path.display()))?;
+    let mut out = std::io::BufWriter::new(out);
 
     // Header — matches RSeQC's exact format (50-char separator)
     writeln!(out, "\n#==================================================")?;
@@ -317,6 +318,7 @@ pub fn write_bam_stat(result: &BamStatResult, output_path: &Path) -> Result<()> 
     )?;
 
     debug!("Wrote bam_stat output to {}", output_path.display());
+    out.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/flagstat.rs
+++ b/src/rna/rseqc/flagstat.rs
@@ -43,8 +43,9 @@ fn fmt_pct(numerator: u64, denominator: u64) -> String {
 pub fn write_flagstat(result: &BamStatResult, output_path: &Path) -> Result<()> {
     use std::io::Write;
 
-    let mut out = std::fs::File::create(output_path)
+    let out = std::fs::File::create(output_path)
         .with_context(|| format!("Failed to create flagstat file: {}", output_path.display()))?;
+    let mut out = std::io::BufWriter::new(out);
 
     // Total = primary + secondary + supplementary (all QC states)
     let total = result.total_records;
@@ -148,6 +149,7 @@ pub fn write_flagstat(result: &BamStatResult, output_path: &Path) -> Result<()> 
     )?;
 
     debug!("Wrote flagstat output to {}", output_path.display());
+    out.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/idxstats.rs
+++ b/src/rna/rseqc/idxstats.rs
@@ -33,8 +33,9 @@ pub fn write_idxstats(
 ) -> Result<()> {
     use std::io::Write;
 
-    let mut out = std::fs::File::create(output_path)
+    let out = std::fs::File::create(output_path)
         .with_context(|| format!("Failed to create idxstats file: {}", output_path.display()))?;
+    let mut out = std::io::BufWriter::new(out);
 
     // One line per reference from the BAM header
     for (tid, (name, length)) in header_refs.iter().enumerate() {
@@ -50,6 +51,7 @@ pub fn write_idxstats(
     writeln!(out, "*\t0\t0\t{}", result.unplaced_unmapped)?;
 
     debug!("Wrote idxstats output to {}", output_path.display());
+    out.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/infer_experiment.rs
+++ b/src/rna/rseqc/infer_experiment.rs
@@ -156,8 +156,9 @@ pub fn write_infer_experiment<P: AsRef<Path>>(
     output_path: P,
 ) -> Result<()> {
     let output_path = output_path.as_ref();
-    let mut writer = fs::File::create(output_path)
+    let writer = fs::File::create(output_path)
         .with_context(|| format!("Failed to create output file: {}", output_path.display()))?;
+    let mut writer = std::io::BufWriter::new(writer);
 
     match result.library_type.as_str() {
         "PairEnd" => {
@@ -207,6 +208,7 @@ pub fn write_infer_experiment<P: AsRef<Path>>(
         }
     }
 
+    writer.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/inner_distance.rs
+++ b/src/rna/rseqc/inner_distance.rs
@@ -297,8 +297,9 @@ pub fn build_histogram(
 
 /// Write the per-pair detail file.
 pub fn write_detail_file(result: &InnerDistanceResult, path: &str) -> Result<()> {
-    let mut file = std::fs::File::create(path)
+    let file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create detail file: {}", path))?;
+    let mut file = std::io::BufWriter::new(file);
 
     for pair in &result.pairs {
         let dist_str = match pair.distance {
@@ -308,18 +309,21 @@ pub fn write_detail_file(result: &InnerDistanceResult, path: &str) -> Result<()>
         writeln!(file, "{}\t{}\t{}", pair.name, dist_str, pair.classification)?;
     }
 
+    file.flush()?;
     Ok(())
 }
 
 /// Write the frequency (histogram) file.
 pub fn write_freq_file(result: &InnerDistanceResult, path: &str) -> Result<()> {
-    let mut file = std::fs::File::create(path)
+    let file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create frequency file: {}", path))?;
+    let mut file = std::io::BufWriter::new(file);
 
     for &(bin_start, bin_end, count) in &result.histogram {
         writeln!(file, "{}\t{}\t{}", bin_start, bin_end, count)?;
     }
 
+    file.flush()?;
     Ok(())
 }
 
@@ -330,8 +334,9 @@ pub fn write_r_script(
     path: &str,
     step: i64,
 ) -> Result<()> {
-    let mut file = std::fs::File::create(path)
+    let file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create R script: {}", path))?;
+    let mut file = std::io::BufWriter::new(file);
 
     // Build bin center and count vectors
     let bin_centers: Vec<String> = result
@@ -374,13 +379,15 @@ pub fn write_r_script(
     writeln!(file, "lines(density(fragsize,bw={}),col='red')", 2 * step)?;
     writeln!(file, "dev.off()")?;
 
+    file.flush()?;
     Ok(())
 }
 
 /// Write the summary text file.
 pub fn write_summary(result: &InnerDistanceResult, path: &str) -> Result<()> {
-    let mut file = std::fs::File::create(path)
+    let file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create summary file: {}", path))?;
+    let mut file = std::io::BufWriter::new(file);
 
     // Count classifications
     let mut same_chrom_no = 0u64;
@@ -432,6 +439,7 @@ pub fn write_summary(result: &InnerDistanceResult, path: &str) -> Result<()> {
         }
     }
 
+    file.flush()?;
     Ok(())
 }
 
@@ -441,8 +449,9 @@ pub fn write_summary(result: &InnerDistanceResult, path: &str) -> Result<()> {
 /// which reconstructs fragment sizes from histogram bins (bin center = start + step/2,
 /// repeated by count) and computes mean/median/sd via R's functions.
 pub fn write_mean_file(result: &InnerDistanceResult, sample_name: &str, path: &str) -> Result<()> {
-    let mut file = std::fs::File::create(path)
+    let file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create mean file: {}", path))?;
+    let mut file = std::io::BufWriter::new(file);
 
     writeln!(file, "Name\tMean\tMedian\tsd")?;
 
@@ -493,6 +502,7 @@ pub fn write_mean_file(result: &InnerDistanceResult, sample_name: &str, path: &s
         }
     }
 
+    file.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/junction_annotation.rs
+++ b/src/rna/rseqc/junction_annotation.rs
@@ -128,8 +128,9 @@ fn format_chrom(chrom: &str) -> String {
 ///
 /// Format matches RSeQC's `.junction.xls` output.
 pub fn write_junction_xls(results: &JunctionResults, path: &Path) -> Result<()> {
-    let mut f = std::fs::File::create(path)
+    let f = std::fs::File::create(path)
         .with_context(|| format!("Failed to create file: {}", path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     writeln!(
         f,
@@ -151,6 +152,7 @@ pub fn write_junction_xls(results: &JunctionResults, path: &Path) -> Result<()> 
         )?;
     }
 
+    f.flush()?;
     Ok(())
 }
 
@@ -159,8 +161,9 @@ pub fn write_junction_xls(results: &JunctionResults, path: &Path) -> Result<()> 
 /// Each junction is represented with 1bp exon blocks flanking the intron,
 /// matching the reference output format.
 pub fn write_junction_bed(results: &JunctionResults, path: &Path) -> Result<()> {
-    let mut f = std::fs::File::create(path)
+    let f = std::fs::File::create(path)
         .with_context(|| format!("Failed to create file: {}", path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     // Output junctions in BAM encounter order (IndexMap preserves insertion order)
     for (junction, (count, class)) in &results.junctions {
@@ -185,6 +188,7 @@ pub fn write_junction_bed(results: &JunctionResults, path: &Path) -> Result<()> 
         )?;
     }
 
+    f.flush()?;
     Ok(())
 }
 
@@ -197,8 +201,9 @@ pub fn write_junction_interact_bed(
     bam_file: &str,
     path: &Path,
 ) -> Result<()> {
-    let mut f = std::fs::File::create(path)
+    let f = std::fs::File::create(path)
         .with_context(|| format!("Failed to create file: {}", path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     // Track header
     writeln!(
@@ -238,6 +243,7 @@ pub fn write_junction_interact_bed(
         )?;
     }
 
+    f.flush()?;
     Ok(())
 }
 
@@ -245,8 +251,9 @@ pub fn write_junction_interact_bed(
 ///
 /// Generates two pie charts: splice events and splice junctions.
 pub fn write_junction_plot_r(results: &JunctionResults, prefix: &str, path: &Path) -> Result<()> {
-    let mut f = std::fs::File::create(path)
+    let f = std::fs::File::create(path)
         .with_context(|| format!("Failed to create file: {}", path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     // Event-level percentages — denominator includes filtered events to match RSeQC
     let (e_known_pct, e_partial_pct, e_novel_pct) = if results.total_events > 0 {
@@ -303,6 +310,7 @@ pub fn write_junction_plot_r(results: &JunctionResults, prefix: &str, path: &Pat
     )?;
     writeln!(f, "dev.off()")?;
 
+    f.flush()?;
     Ok(())
 }
 
@@ -312,8 +320,9 @@ pub fn write_junction_plot_r(results: &JunctionResults, prefix: &str, path: &Pat
 /// header lines ("Reading reference gene model …", "Load BAM file …") and
 /// footer lines ("Create BED file …", "Create Interact file …").
 pub fn write_summary(results: &JunctionResults, path: &Path, gtf_path: &str) -> Result<()> {
-    let mut f = std::fs::File::create(path)
+    let f = std::fs::File::create(path)
         .with_context(|| format!("Failed to create file: {}", path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     // Header lines matching RSeQC's junction_annotation.py log output
     let gtf_filename = Path::new(gtf_path)
@@ -336,6 +345,7 @@ pub fn write_summary(results: &JunctionResults, path: &Path, gtf_path: &str) -> 
     writeln!(f, "Create BED file ...")?;
     writeln!(f, "Create Interact file ...")?;
 
+    f.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/junction_saturation.rs
+++ b/src/rna/rseqc/junction_saturation.rs
@@ -30,8 +30,9 @@ pub struct SaturationResult {
 /// Produces an R script matching RSeQC's `junctionSaturation_plot.r` format.
 pub fn write_r_script(result: &SaturationResult, prefix: &str) -> Result<()> {
     let r_path = format!("{prefix}.junctionSaturation_plot.r");
-    let mut f =
+    let f =
         std::fs::File::create(&r_path).with_context(|| format!("creating R script: {r_path}"))?;
+    let mut f = std::io::BufWriter::new(f);
 
     let pdf_path = format!("{prefix}.junctionSaturation_plot.pdf");
 
@@ -74,12 +75,14 @@ pub fn write_r_script(result: &SaturationResult, prefix: &str) -> Result<()> {
     writeln!(f, "dev.off()")?;
 
     info!("Wrote R script: {r_path}");
+    f.flush()?;
     Ok(())
 }
 
 /// Write a summary text file with junction saturation statistics.
 pub fn write_summary(result: &SaturationResult, path: &str) -> Result<()> {
-    let mut f = std::fs::File::create(path).with_context(|| format!("creating summary: {path}"))?;
+    let f = std::fs::File::create(path).with_context(|| format!("creating summary: {path}"))?;
+    let mut f = std::io::BufWriter::new(f);
 
     writeln!(
         f,
@@ -97,6 +100,7 @@ pub fn write_summary(result: &SaturationResult, path: &str) -> Result<()> {
     }
 
     info!("Wrote summary: {path}");
+    f.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/read_duplication.rs
+++ b/src/rna/rseqc/read_duplication.rs
@@ -40,14 +40,16 @@ pub struct ReadDuplicationResult {
 /// * `histogram` - The duplication histogram to write
 /// * `path` - Output file path
 fn write_histogram(histogram: &DupHistogram, path: &Path) -> Result<()> {
-    let mut file = std::fs::File::create(path)
+    let file = std::fs::File::create(path)
         .with_context(|| format!("Failed to create output file: {}", path.display()))?;
+    let mut file = std::io::BufWriter::new(file);
 
     writeln!(file, "Occurrence\tUniqReadNumber")?;
     for (occurrence, uniq_count) in histogram {
         writeln!(file, "{}\t{}", occurrence, uniq_count)?;
     }
 
+    file.flush()?;
     Ok(())
 }
 
@@ -111,7 +113,8 @@ fn write_r_script(
     path: &Path,
 ) -> Result<()> {
     use std::io::Write;
-    let mut f = std::fs::File::create(path)?;
+    let f = std::fs::File::create(path)?;
+    let mut f = std::io::BufWriter::new(f);
 
     writeln!(f, "pdf('{stem}.DupRate_plot.pdf')")?;
     writeln!(f, "par(mar=c(5,4,4,5),las=0)")?;
@@ -146,6 +149,7 @@ fn write_r_script(
     writeln!(f, "mtext(4, text = \"Reads %\", line = 2)")?;
     writeln!(f, "dev.off()")?;
 
+    f.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/stats.rs
+++ b/src/rna/rseqc/stats.rs
@@ -55,8 +55,9 @@ fn fmt_sci(v: f64) -> String {
 /// * `result` - The computed BAM statistics
 /// * `output_path` - Path to write the stats file
 pub fn write_stats(result: &BamStatResult, output_path: &Path) -> Result<()> {
-    let mut out = std::fs::File::create(output_path)
+    let out = std::fs::File::create(output_path)
         .with_context(|| format!("Failed to create stats file: {}", output_path.display()))?;
+    let mut out = std::io::BufWriter::new(out);
 
     // Header comment — MultiQC detects "This file was produced by samtools stats"
     writeln!(out, "# This file was produced by samtools stats and RustQC")?;
@@ -387,6 +388,7 @@ pub fn write_stats(result: &BamStatResult, output_path: &Path) -> Result<()> {
     write_gc_depth(&mut out, &result.gcd_bins, result)?;
 
     debug!("Wrote samtools stats output to {}", output_path.display());
+    out.flush()?;
     Ok(())
 }
 

--- a/src/rna/rseqc/tin.rs
+++ b/src/rna/rseqc/tin.rs
@@ -665,8 +665,9 @@ fn fill_aligned_blocks(record: &bam::Record, buf: &mut Vec<(u64, u64)>) {
 ///
 /// Format: TSV with header geneID\tchrom\ttx_start\ttx_end\tTIN
 pub fn write_tin(results: &TinResults, output_path: &Path) -> Result<()> {
-    let mut f = std::fs::File::create(output_path)
+    let f = std::fs::File::create(output_path)
         .with_context(|| format!("Failed to create TIN output: {}", output_path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     writeln!(f, "geneID\tchrom\ttx_start\ttx_end\tTIN")?;
 
@@ -698,6 +699,7 @@ pub fn write_tin(results: &TinResults, output_path: &Path) -> Result<()> {
         }
     }
 
+    f.flush()?;
     Ok(())
 }
 
@@ -705,8 +707,9 @@ pub fn write_tin(results: &TinResults, output_path: &Path) -> Result<()> {
 ///
 /// Format: Bam_file\tTIN(mean)\tTIN(median)\tTIN(stdev)
 pub fn write_tin_summary(results: &TinResults, bam_name: &str, output_path: &Path) -> Result<()> {
-    let mut f = std::fs::File::create(output_path)
+    let f = std::fs::File::create(output_path)
         .with_context(|| format!("Failed to create TIN summary: {}", output_path.display()))?;
+    let mut f = std::io::BufWriter::new(f);
 
     let scores: Vec<f64> = results
         .transcripts
@@ -732,6 +735,7 @@ pub fn write_tin_summary(results: &TinResults, bam_name: &str, output_path: &Pat
     writeln!(f, "Bam_file\tTIN(mean)\tTIN(median)\tTIN(stdev)")?;
     writeln!(f, "{}\t{}\t{}\t{}", bam_name, mean, median, stdev)?;
 
+    f.flush()?;
     Ok(())
 }
 


### PR DESCRIPTION
## What

Wraps the remaining 28 output-file writers in `BufWriter`. Nine call sites already did this; the rest wrote line by line straight into a `std::fs::File`, i.e. one `write(2)` syscall per line.

## Why it matters

Several outputs scale with input size:

| file | lines on the benchmark input |
|---|---|
| `rseqc/inner_distance/*.inner_distance.txt` | 1,000,000 (one per read pair) |
| `rseqc/tin/*.tin.xls` | 150,001 (one per transcript) |
| `rseqc/junction_annotation/*.junction.{xls,bed,Interact.bed}` | 73,663 each |
| `featurecounts/*.tsv`, `dupradar/*_dupMatrix.txt` | 60,001 each (already buffered) |

## Measurement

Synthetic 4M-read coordinate-sorted BAM (24 contigs, random sequences), 1.2M-line GTF / 60k genes, aarch64 macOS, `--threads 4`. Five interleaved runs per binary, medians:

| | real | user | sys |
|---|---|---|---|
| `main` | 23.16 s | 24.03 s | 13.45 s |
| this PR | **9.72 s** | 23.20 s | **0.70 s** |

**2.4x wall clock.** System time falls 95% — that is the syscall traffic disappearing. User time is unchanged, which is the expected signature: the same work, far fewer syscalls.

## Correctness

Each converted writer gets an explicit `flush()?` before returning, so a failing final flush is reported instead of being swallowed by `BufWriter`'s `Drop`.

All deterministic outputs are byte-identical before and after. `cargo test --release` passes (200 + 12 + 18 + 2).

## Pre-existing issue found while verifying

Three outputs are **not reproducible run-to-run on `main` alone** — two runs of the same binary on the same input differ:

- `dupradar/*_duprateExpDens.svg` (and the matching `.png`)
- `qualimap/qualimapReport.html`
- `qualimap/rnaseq_qc_results.txt`

The differences are pure line/element reordering of equal-valued entries, so no number changes, but the files do not hash-match. It looks like `HashMap` iteration order reaching output (`compute_bias` in `qualimap/output.rs` has a comment acknowledging a related tie-break). Unrelated to this PR — happy to open a separate issue.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #143.
