### PR TITLE
build(deps): update openssl-sys to 0.9.117 for OpenSSL 4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Problem

`Cargo.lock` pins `openssl-sys 0.9.112`, which refuses to build against OpenSSL 4:

```rust
// openssl-sys-0.9.112/build/main.rs:439
if openssl_version >= 0x4_00_00_00_0 {
    version_error()   // panic!("... no supported version of OpenSSL found ...")
}
```

The dependency chain is `rust-htslib` → `hts-sys` → `curl-sys` → `openssl-sys`, so any
build of RustQC with `--locked` on a system whose OpenSSL is 4.x fails at that check.

OpenSSL 4 support landed in `openssl-sys 0.9.114`; from that release the same code path
reads:

```rust
// openssl-sys-0.9.117/build/main.rs:444
if openssl_version >= 0x5_00_00_00_0 {
    version_error()
} else if openssl_version >= 0x4_00_00_00_0 {
    Version::Openssl4xx
}
```

This matters for distributions that have already moved: Homebrew is migrating its
formulae to `openssl@4`, and a RustQC formula currently has to pin `openssl@3` to build.

## Change

`cargo update -p openssl-sys`, which moves `0.9.112` → `0.9.117`. `Cargo.toml` is
untouched: the bump is within the existing semver range, so this is a lockfile-only
change of two lines.

## Verification

```
cargo build --release --locked     # ok
cargo test  --release --locked     # 232 passed, 0 failed
```

Independent of #130, which updates `hts-sys`; the two touch different lockfile entries
and can land in either order.
