### PR TITLE
ci: extend Dependabot to cargo, npm and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,34 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` only declared the `github-actions` ecosystem. The Rust crate, the Astro docs site (`/docs`) and the Dockerfile base image got no version updates. The `cargo` and `npm_and_yarn` bumps merged so far (#93, #99, #100) came from security advisories, which run without config.

## Change

Adds three weekly ecosystems:

| Ecosystem | Directory | Manifest |
|---|---|---|
| `cargo` | `/` | `Cargo.toml` / `Cargo.lock` |
| `npm` | `/docs` | `docs/package.json` |
| `docker` | `/` | `Dockerfile` (`rust:1-bookworm`) |

Minor/patch updates are grouped per ecosystem, and all action bumps are grouped into one PR, so weekly noise stays at a few PRs instead of one per dependency. Major bumps still arrive individually. `open-pull-requests-limit: 5` on cargo and npm.

## Test

`check-yaml` (pre-commit) passes; config parses as valid YAML. Dependabot itself validates the file on merge to the default branch (Insights → Dependency graph → Dependabot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)