### PR TITLE
fix(deps): bump crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
`cargo audit` currently fails on `main`.

```
Crate:    crossbeam-epoch
Version:  0.9.18
Title:    Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and
          `Shared` when the underlying pointer is invalid
ID:       RUSTSEC-2026-0204
Solution: Upgrade to >=0.9.20
```

It arrives transitively through rayon. This is a lockfile bump to 0.9.20, the advisory's own recommended fix; 95 other dependencies are unchanged and the test suite is unaffected. `cargo audit` then passes, leaving only the four advisories the workflow already tolerates.

## How this surfaced

Fork pull requests need a maintainer to approve their workflow runs, so no job has executed on any of the open PRs in #157 and #163: every run sits at `action_required` and eventually reports `failure` with zero jobs, which reads as a code failure but is not one.

To get real signal I ran the same workflow on a fork branch, where no approval is needed. Six of the seven jobs passed on that branch: `Test (linux-x86_64)`, `Test (linux-x86_64-v3)`, `Test (macos-aarch64)`, `Clippy`, `Formatting` and `MSRV check`. The only failure was `Security audit`, and reproducing it on a clean `main` checkout confirmed it is pre-existing rather than anything the open PRs introduce.

Worth merging on its own, independently of those series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)